### PR TITLE
Add get_by_spatial GraphQL tool to MCP

### DIFF
--- a/dis-locate-apis-v2/mcp_servers/tools/graphql_services.py
+++ b/dis-locate-apis-v2/mcp_servers/tools/graphql_services.py
@@ -1,6 +1,6 @@
 """
 GraphQL Services Tools Module
-Contains 22 tools for property, demographics, risk, and advanced GraphQL queries
+Contains 23 tools for property, demographics, risk, and advanced GraphQL queries
 """
 from mcp.types import Tool
 from mcp_servers.tools.base_tool import handle_tool_call  # noqa: F401
@@ -217,7 +217,7 @@ def get_tools() -> list[Tool]:
         }
     ),
 
-    # Advanced GraphQL tools  (5 tools)
+    # Advanced GraphQL tools  (6 tools)
     Tool(
         name="get_addresses_detailed",
         description="""Get detailed address information using custom GraphQL query.
@@ -340,6 +340,36 @@ Available fields in places data section:
             "type": "object",
             "properties": {
                 "data": {"type": "object", "description": "GraphQL query with variables: address (string, required), country (string, default 'US')"}
+            },
+            "required": ["data"]
+        }
+    ),
+    Tool(
+        name="get_by_spatial",
+        description="""Run GraphQL getBySpatial queries with custom geometry/location input.
+        
+Example request:
+{'data': {
+    'query': 'query GetBySpatial($spatial: SpatialInput!, $country: String) { getBySpatial(spatial: $spatial, country: $country) { addresses(pageNumber: 1, pageSize: 20) { metadata { pageNumber pageCount totalPages count vintage } data { preciselyID addressNumber streetName city admin1ShortName postalCode } } } }',
+    'variables': {
+        'spatial': {
+            'format': 'WKT',
+            'value': 'POINT (-104.9903 39.7392)'
+        },
+        'country': 'US'
+    }
+}}
+
+Returns: Addresses/features matched by a spatial query instead of a street address.
+
+IMPORTANT:
+- Provide GraphQL payload as data.query and data.variables
+- Keep queried fields conservative to avoid GraphQL schema errors
+- If your schema uses different variable/field names for getBySpatial, adjust query text accordingly""",
+        inputSchema={
+            "type": "object",
+            "properties": {
+                "data": {"type": "object", "description": "GraphQL query with variables for getBySpatial (geometry/location input)"}
             },
             "required": ["data"]
         }

--- a/dis-locate-apis-v2/precisely/graphql_advanced.py
+++ b/dis-locate-apis-v2/precisely/graphql_advanced.py
@@ -1,4 +1,4 @@
-"""Advanced GraphQL API methods (5 tools — LLM constructs queries directly)."""
+"""Advanced GraphQL API methods (6 tools — LLM constructs queries directly)."""
 
 import json
 import logging
@@ -76,4 +76,18 @@ class GraphQLAdvancedMixin:
             return self._validate_graphql_response(response.json(), "get_places_by_address")
         except Exception as e:
             logger.error(f"Places by address error: {e}")
+            return {"error": str(e)}
+
+    def get_by_spatial(self, data: Dict, **kwargs) -> Dict[str, Any]:
+        """Run getBySpatial query via GraphQL"""
+        try:
+            url = f"{self.base_url}/data-graph/graphql"
+            json_data = data
+            logger.debug(f"[get_by_spatial] Request payload: {json.dumps(json_data, indent=2)}")
+            response = self.session.post(url, json=json_data)
+            logger.debug(f"[get_by_spatial] Raw response: {response.text}")
+            response.raise_for_status()
+            return self._validate_graphql_response(response.json(), "get_by_spatial")
+        except Exception as e:
+            logger.error(f"Get by spatial error: {e}")
             return {"error": str(e)}

--- a/dis-locate-apis-v2/readme.md
+++ b/dis-locate-apis-v2/readme.md
@@ -1,10 +1,10 @@
 ﻿# Precisely MCP Server
 
-A Model Context Protocol (MCP) server that exposes 71 Precisely location intelligence APIs to AI assistants like Claude Desktop, VS Code, Cursor, LangChain, LlamaIndex, and custom applications.
+A Model Context Protocol (MCP) server that exposes 72 Precisely location intelligence APIs to AI assistants like Claude Desktop, VS Code, Cursor, LangChain, LlamaIndex, and custom applications.
 
 ## Features
 
-- **71 Production-Ready API Tools**: Complete location intelligence suite
+- **72 Production-Ready API Tools**: Complete location intelligence suite
 - **Dual Transport Support**: stdio (default) and Streamable HTTP transports
 - **MCP Protocol**: Standard interface for AI assistants  
 - **100% Test Coverage**: Comprehensive unified test suite with 72/72 tests passing
@@ -321,7 +321,7 @@ Failed:    0
 Pass Rate: 100.0%
 ```
 
-## Available APIs (71 Tools)
+## Available APIs (72 Tools)
 
 ### Geocoding & Address (9 tools)
 
@@ -394,47 +394,48 @@ Pass Rate: 100.0%
 43. timezone_addresses - Get timezone for addresses
 44. timezone_locations - Get timezone for coordinates
 
-### GraphQL Advanced Queries (5 tools)
+### GraphQL Advanced Queries (6 tools)
 
 45. get_addresses_detailed - Comprehensive address details via GraphQL
 46. get_parcel_by_owner_detailed - Parcel ownership queries via GraphQL
 47. get_address_family - Related addresses via GraphQL
 48. get_serviceability - Broadband/utility serviceability via GraphQL
 49. get_places_by_address - Places/points of interest by address via GraphQL
+50. get_by_spatial - Spatial geometry/address GraphQL query support
 
 ### Spatial Analysis (7 tools)
 
-50. find_nearest_candidates - Find nearest spatial features by distance
-51. search_at_location - Search for features at/near a location
-52. overlap - Identify spatial overlaps between geometries
-53. get_spatial_products - Get available spatial data product metadata
-54. list_spatial_tables - List available spatial tables
-55. get_table_metadata - Get metadata for a specific spatial table
-56. summarize - Aggregate spatial data within a defined area
+51. find_nearest_candidates - Find nearest spatial features by distance
+52. search_at_location - Search for features at/near a location
+53. overlap - Identify spatial overlaps between geometries
+54. get_spatial_products - Get available spatial data product metadata
+55. list_spatial_tables - List available spatial tables
+56. get_table_metadata - Get metadata for a specific spatial table
+57. summarize - Aggregate spatial data within a defined area
 
 ### OGC API Features (10 tools)
 
-57. ogc_landing_page - OGC API landing page with links
-58. ogc_api_definition - Complete OpenAPI definition
-59. ogc_functions - Available spatial functions
-60. ogc_conformance - OGC conformance declaration
-61. ogc_collections - List feature collections
-62. ogc_collection - Information about a specific collection
-63. ogc_collection_schema - Schema for a collection
-64. ogc_collection_queryables - Queryable attributes for a collection
-65. ogc_collection_items - Data records from a collection
-66. ogc_feature_by_id - Get a specific feature by ID
+58. ogc_landing_page - OGC API landing page with links
+59. ogc_api_definition - Complete OpenAPI definition
+60. ogc_functions - Available spatial functions
+61. ogc_conformance - OGC conformance declaration
+62. ogc_collections - List feature collections
+63. ogc_collection - Information about a specific collection
+64. ogc_collection_schema - Schema for a collection
+65. ogc_collection_queryables - Queryable attributes for a collection
+66. ogc_collection_items - Data records from a collection
+67. ogc_feature_by_id - Get a specific feature by ID
 
 ### WMS - Web Map Service (2 tools, 3 tests)
 
-67. wms_get_request - WMS GET handler (GetCapabilities/GetMap/GetFeatureInfo) — tested with both GetCapabilities and GetFeatureInfo (2 tests)
-68. wms_post_get_map - WMS POST GetMap with custom SLD styling
+68. wms_get_request - WMS GET handler (GetCapabilities/GetMap/GetFeatureInfo) — tested with both GetCapabilities and GetFeatureInfo (2 tests)
+69. wms_post_get_map - WMS POST GetMap with custom SLD styling
 
 ### WMTS - Web Map Tile Service (3 tools)
 
-69. wmts_request - WMTS KVP handler (GetCapabilities/GetTile)
-70. wmts_get_standard_tile - WMTS tile via RESTful standard profile
-71. wmts_get_simple_tile - WMTS tile via RESTful simple profile
+70. wmts_request - WMTS KVP handler (GetCapabilities/GetTile)
+71. wmts_get_standard_tile - WMTS tile via RESTful standard profile
+72. wmts_get_simple_tile - WMTS tile via RESTful simple profile
 
 ## Project Structure
 

--- a/dis-locate-apis-v2/test_precisely_mcp.py
+++ b/dis-locate-apis-v2/test_precisely_mcp.py
@@ -2,7 +2,7 @@
 Unified Test Suite for Precisely MCP Server
 Combines 3-tier testing: Layer 1 (API Core) → Layer 2 (MCP Server) → Layer 3 (Functional)
 
-Tests all 71 Precisely API tools with comprehensive validation and detailed logging
+Tests all 72 Precisely API tools with comprehensive validation and detailed logging
 """
 
 import os
@@ -122,10 +122,10 @@ class PreciselyMCPTestSuite:
         methods = [m for m in dir(self.api) if not m.startswith('_') and callable(getattr(self.api, m))]
         logger.info(f"  Found {len(methods)} API methods")
         
-        if len(methods) != 71:
-            logger.warning(f"  [WARN] Expected 71 methods, found {len(methods)}")
+        if len(methods) != 72:
+            logger.warning(f"  [WARN] Expected 72 methods, found {len(methods)}")
         else:
-            logger.info("  [PASS] All 71 API methods present")
+            logger.info("  [PASS] All 72 API methods present")
         
         # Test 3: Quick smoke tests
         logger.info("\n[3/3] Running Quick Smoke Tests...")
@@ -186,10 +186,10 @@ class PreciselyMCPTestSuite:
                 logger.error(f"  [FAIL] Duplicate tools found: {set(duplicates)}")
                 return False
             
-            if len(tools) != 71:
-                logger.warning(f"  [WARN] Expected 71 tools, found {len(tools)}")
+            if len(tools) != 72:
+                logger.warning(f"  [WARN] Expected 72 tools, found {len(tools)}")
             else:
-                logger.info("  [PASS] All 71 MCP tools defined")
+                logger.info("  [PASS] All 72 MCP tools defined")
             
         except Exception as e:
             logger.error(f"  [FAIL] Failed to load MCP server: {e}")
@@ -566,6 +566,9 @@ class PreciselyMCPTestSuite:
             
             ("Get Serviceability", "get_serviceability", "What broadband services are available at 2755 Milwaukee St, Denver, 80238 CO?",
              {"data": {"query": "query GetServiceability($address: String!, $country: String) { getByAddress(address: $address, country: $country) { addresses(pageNumber: 1, pageSize: 1) { data { preciselyID serviceability { metadata { pageNumber pageCount totalPages count vintage } data { serviceabilityID preciselyID serviceableAddress } } } } } }", "variables": {"address": "2755 Milwaukee St, Denver, 80238 CO", "country": "US"}}}),
+
+            ("Get By Spatial", "get_by_spatial", "Run getBySpatial GraphQL query for a WKT point near Denver",
+             {"data": {"query": "query GetBySpatial($spatial: SpatialInput!, $country: String) { getBySpatial(spatial: $spatial, country: $country) { addresses(pageNumber: 1, pageSize: 20) { metadata { pageNumber pageCount totalPages count vintage } data { preciselyID addressNumber streetName city admin1ShortName postalCode } } } }", "variables": {"spatial": {"format": "WKT", "value": "POINT (-104.9903 39.7392)"}, "country": "US"}}}),
             
             ("Get Places by Address", "get_places_by_address", "What places and points of interest are near 123 Main St, Boston, MA 02101?",
              {"data": {"query": "query GetPlacesByAddress($address: String!, $country: String) { getByAddress(address: $address, country: $country) { places(pageNumber: 1, pageSize: 20) { metadata { pageNumber pageCount totalPages count vintage } data { PBID pointOfInterestID preciselyID businessName brandName city admin1ShortName postalCode formattedAddress longitude latitude phone email web lineOfBusiness sic8Description } } } }", "variables": {"address": "123 Main St, Boston, MA 02101", "country": "US"}}}),


### PR DESCRIPTION
## Summary
- Add get_by_spatial tool definition in MCP GraphQL services.
- Add get_by_spatial method to GraphQLAdvancedMixin so the tool has a matching API implementation.
- Update GraphQL tool count comments/docs from 22 to 23 and advanced GraphQL tools from 5 to 6.

## Validation
- python3 -m py_compile precisely/graphql_advanced.py mcp_servers/tools/graphql_services.py
- Registry build validated tool-to-method mapping and includes get_by_spatial.

## Notes
- This is built on top of PR #26 (refactoring) where modularization was introduced.