### PR TITLE
consolidate-dis-locate-tools

### DIFF
--- a/dis-locate-apis-v2/mcp_servers/server.py
+++ b/dis-locate-apis-v2/mcp_servers/server.py
@@ -27,7 +27,7 @@ def create_server(precisely_api, tools: list, tool_module_map: dict) -> Server:
 
     @app.list_tools()
     async def list_tools() -> list[Tool]:
-        """List all 68 Precisely API tools."""
+        """List all 51 Precisely API tools."""
         return tools
 
     @app.call_tool()

--- a/dis-locate-apis-v2/mcp_servers/tools/geocoding_address.py
+++ b/dis-locate-apis-v2/mcp_servers/tools/geocoding_address.py
@@ -1,43 +1,9 @@
 """
 Geocoding & Address Tools Module
-Contains 9 tools for geocoding, address verification, autocomplete, and address parsing
+Contains 6 tools for geocoding, address verification, autocomplete, and address parsing
 """
 from mcp.types import Tool
 from mcp_servers.tools.base_tool import handle_tool_call  # noqa: F401
-
-_AUTOCOMPLETE_ADDRESS_SCHEMA = {
-    "type": "object",
-    "description": "Partial address input for autocomplete suggestions.",
-    "properties": {
-        "addressLines": {
-            "type": "array",
-            "items": {"type": "string"},
-            "description": "Partial street address text to autocomplete (e.g., ['1700 District'])."
-        },
-        "country": {
-            "type": "string",
-            "description": "Values per ISO 3166-1 standard for country codes (alpha-2, alpha-3, or numeric format) e.g. USA, US or 840"
-        },
-        "city": {"type": "string", "description": "Optional city to narrow suggestions."},
-        "admin1": {"type": "string", "description": "Optional state/province abbreviation to narrow suggestions."},
-        "postalCode": {"type": "string", "description": "Optional postal code to narrow suggestions."}
-    },
-    "required": ["addressLines", "country"]
-}
-
-_AUTOCOMPLETE_PREFERENCES_SCHEMA = {
-    "type": "object",
-    "description": "Preferences for controlling autocomplete behavior.",
-    "properties": {
-        "maxResults": {
-            "type": "integer",
-            "description": "Maximum number of suggestions to return.",
-            "default": 5,
-            "minimum": 1,
-            "maximum": 25
-        },
-    }
-}
 
 
 def get_tools() -> list[Tool]:
@@ -45,16 +11,15 @@ def get_tools() -> list[Tool]:
     return [
         Tool(
             name="geocode",
-            description=(
-                "Convert a free-text street address into geographic coordinates (latitude/longitude) "
-                "and a structured address record including PB_KEY/PreciselyID. "
-                "Use this tool when you need lat/lon from a human-readable address string. "
-                "Do NOT use for reverse lookup (coordinates → address) — use reverse_geocode instead. "
-                "Do NOT use when you already have a Precisely key like PB_KEY — use lookup instead. "
-                "Do NOT use when address validation and standardization is the goal — use verify_address instead "
-                "Output: Object with latitude, longitude, standardized address components "
-                "(street number, street name, city, state, postal code), and confidence/match quality indicators, other details."
-            ),
+            description="""Convert a free-text street address into geographic coordinates (latitude/longitude) and a structured
+address record including PB_KEY/PreciselyID. Use this tool when you need lat/lon from a
+human-readable address string.
+Do NOT use for reverse lookup (coordinates → address) — use reverse_geocode instead.
+Do NOT use when you already have a Precisely key like PB_KEY — use lookup instead.
+Do NOT use when address validation and standardization is the goal — use verify_address instead.
+
+Output: Object with latitude, longitude, standardized address components (street number, street
+name, city, state, postal code), and confidence/match quality indicators.""",
             inputSchema={
                 "type": "object",
                 "properties": {
@@ -73,14 +38,13 @@ def get_tools() -> list[Tool]:
         ),
         Tool(
             name="reverse_geocode",
-            description=(
-                "Convert geographic coordinates (latitude, longitude) into a nearest matching street address. "
-                "Use this tool when you have a lat/lon pair and need a human-readable address. "
-                "Do NOT use when you have a text address — use geocode instead. "
-                "Do NOT use when you need structured data beyond the address (e.g., property info)"
-                "Output: Object with the nearest matching standardized address (street, city, state, postal code, country), "
-                "distance from the input coordinate to the matched address, other details."
-            ),
+            description="""Convert geographic coordinates (latitude, longitude) into a nearest matching street address.
+Use this tool when you have a lat/lon pair and need a human-readable address.
+Do NOT use when you have a text address — use geocode instead.
+Do NOT use when you need structured data beyond the address (e.g., property info).
+
+Output: Object with the nearest matching standardized address (street, city, state, postal code,
+country), and distance from the input coordinate to the matched address.""",
             inputSchema={
                 "type": "object",
                 "properties": {
@@ -107,16 +71,13 @@ def get_tools() -> list[Tool]:
         ),
         Tool(
             name="verify_address",
-            description=(
-                "Verify, standardize, and correct a postal address. "
-                "Checks whether the address is deliverable, corrects formatting/spelling, "
-                "and returns the standardized form including postal code and address components. "
-                "Use this tool when address quality, deliverability, or standardization is the goal. "
-                "Do NOT use if you only need coordinates — use geocode instead "
-                "(geocode is optimized for coordinate resolution, verify_address is optimized for postal validation). "
-                "Do NOT use for non-postal spatial queries — use geocode or spatial tools instead.\n\n"
-                "Output: Object with standardized address components, deliverability indicators, and match confidence."
-            ),
+            description="""Verify, standardize, and correct a postal address. Checks whether the address is deliverable,
+corrects formatting/spelling, and returns the standardized form including postal code and
+address components. Use this tool when address quality, deliverability, or standardization is the goal.
+Do NOT use if you only need coordinates — use geocode instead.
+Do NOT use for non-postal spatial queries — use geocode or spatial tools instead.
+
+Output: Object with standardized address components, deliverability indicators, and match confidence.""",
             inputSchema={
                 "type": "object",
                 "properties": {
@@ -134,93 +95,102 @@ def get_tools() -> list[Tool]:
             }
         ),
         Tool(
-            name="autocomplete",
-            description=(
-                "Return ranked address autocomplete suggestions for a partial address string. "
-                "Returns up to maxResults matching addresses. "
-                "Suitable for full street address completion (house number + street + city). "
-                "Do NOT use for postal code-only or city-only completion — use autocomplete_postal_city instead. "
-                "Do NOT use for one-time full address resolution — use geocode or verify_address instead. "
-                "For lower-latency consider autocomplete_v2 instead.\n\n"
-                "Output: Array of address suggestion strings with structured address components "
-                "(addressLine, city, state, postal code, country)."
-            ),
-            inputSchema={
-                "type": "object",
-                "properties": {
-                    "address": _AUTOCOMPLETE_ADDRESS_SCHEMA,
-                    "preferences": _AUTOCOMPLETE_PREFERENCES_SCHEMA
-                },
-                "required": ["address"]
-            }
-        ),
-        Tool(
-            name="autocomplete_postal_city",
-            description=(
-                "Return autocomplete suggestions for postal codes and city names — not full street addresses. "
-                "Use when a user is typing a ZIP code, postal code, or city name and you want to offer matching city/postal combinations. "
-                "Do NOT use for full street address completion — use autocomplete or autocomplete_v2 instead. "
-                "Output: Array of postal/city suggestion objects with postal code, city name, state, and country."
-            ),
+            name="autocomplete_address",
+            description="""Return ranked autocomplete suggestions for addresses, postal codes, or city names.
+This single tool covers three modes — the correct endpoint is chosen automatically:
+• Street address: provide address.addressLines + address.country → full address completions.
+  Set express=true for the faster, lower-latency V2 engine.
+• Postal code / city: provide address.postAddress + address.country (+ optional address.type
+  'POSTAL' or 'CITY') → postal/city completions.
+Do NOT use for one-time full address resolution — use geocode or verify_address instead.
+
+Output: Array of prediction objects with predicted address string, structured address components, and an explanation field (for express=false).""",
             inputSchema={
                 "type": "object",
                 "properties": {
                     "address": {
                         "type": "object",
-                        "description": "Postal or city query object.",
-                        "properties": {
-                            "type": {
-                                "type": "string",
-                                "description": "Lookup type. Use 'POSTAL' for postal suggestions, and 'CITY' for city suggestions.",
-                                "enum": ["POSTAL", "CITY"]
+                        "description": (
+                            "Address input. Provide ONE of the following shapes:\n"
+                            "• Street autocomplete: {\"addressLines\": [\"partial street...\"], \"country\": \"USA\", ...}\n"
+                            "• Postal/City autocomplete: {\"postAddress\": \"12180\", \"country\": \"USA\", \"type\": \"POSTAL\"}"
+                        ),
+                        "oneOf": [
+                            {
+                                "title": "Street address input",
+                                "type": "object",
+                                "properties": {
+                                    "addressLines": {
+                                        "type": "array",
+                                        "items": {"type": "string"},
+                                        "description": "Partial street address text to autocomplete (e.g., ['1700 District'])."
+                                    },
+                                    "country": {
+                                        "type": "string",
+                                        "description": "ISO 3166-1 country code (alpha-2, alpha-3, or numeric) e.g. USA, US, or 840."
+                                    },
+                                    "city": {"type": "string", "description": "Optional city to narrow suggestions."},
+                                    "admin1": {"type": "string", "description": "Optional state/province abbreviation."},
+                                    "postalCode": {"type": "string", "description": "Optional postal code to narrow suggestions."}
+                                },
+                                "required": ["addressLines", "country"]
                             },
-                            "postAddress": {
-                                "type": "string",
-                                "description": "Partial postal code or city name to complete (e.g., '12180' or 'Bos')."
-                            },
-                            "country": {
-                                "type": "string",
-                                "description": "Name of country in ISO 3166-1 Alpha-2 or Alpha-3 format, or a common name of the country e.g. USA.",
+                            {
+                                "title": "Postal / City input",
+                                "type": "object",
+                                "properties": {
+                                    "type": {
+                                        "type": "string",
+                                        "description": "Lookup type: 'POSTAL' for postal suggestions, 'CITY' for city suggestions.",
+                                        "enum": ["POSTAL", "CITY"]
+                                    },
+                                    "postAddress": {
+                                        "type": "string",
+                                        "description": "Partial postal code or city name to complete (e.g., '12180' or 'Bos')."
+                                    },
+                                    "country": {
+                                        "type": "string",
+                                        "description": "ISO 3166-1 country code (alpha-2, alpha-3, or numeric) e.g. USA."
+                                    }
+                                },
+                                "required": ["postAddress", "country"]
                             }
-                        },
-                        "required": ["postAddress", "country"]
+                        ]
                     },
-                    "preferences": _AUTOCOMPLETE_PREFERENCES_SCHEMA
-                },
-                "required": ["address"]
-            }
-        ),
-        Tool(
-            name="autocomplete_v2",
-            description=(
-                "Return ranked address autocomplete suggestions using the V2 (express) engine, "
-                "which is faster and optimized for lower latency. "
-                "Use when latency is critical and the user is providing a full street address. "
-                "Do NOT use for postal code or city-only completion — use autocomplete_postal_city instead.\n\n"
-                "Output: Array of address suggestion objects with structured components "
-                "(street, city, state, postal code, country)."
-            ),
-            inputSchema={
-                "type": "object",
-                "properties": {
-                    "address": _AUTOCOMPLETE_ADDRESS_SCHEMA,
-                    "preferences": _AUTOCOMPLETE_PREFERENCES_SCHEMA
+                    "express": {
+                        "type": "boolean",
+                        "description": (
+                            "When true, uses the faster express (V2) autocomplete engine. "
+                            "Only applies to street address mode (addressLines). Ignored for postal/city."
+                        ),
+                        "default": False
+                    },
+                    "preferences": {
+                        "type": "object",
+                        "description": "Preferences for controlling autocomplete behavior.",
+                        "properties": {
+                            "maxResults": {
+                                "type": "integer",
+                                "description": "Maximum number of suggestions to return.",
+                                "default": 5,
+                                "minimum": 1
+                            }
+                        }
+                    }
                 },
                 "required": ["address"]
             }
         ),
         Tool(
             name="lookup",
-            description=(
-                "Retrieve full address record(s) by one or more Precisely keys (internal system identifiers). "
-                "Precisely keys are opaque string keys (e.g., 'P0000GL41OME') that uniquely identify a location "
-                "in the Precisely data platform. "
-                "Use this tool when you already have a Precisely key obtained from a prior call like geocode, ogc_collection_items, others. "
-                "Do NOT use if you only have a human-readable address — use geocode instead. "
-                "Supports batch lookup of multiple keys in a single call.\n\n"
-                "Output: Array of full address records (one per key), each containing standardized address components, "
-                "coordinates, and associated metadata."
-            ),
+            description="""Retrieve full address record(s) by one or more Precisely keys (internal system identifiers).
+Precisely keys are opaque string keys (e.g., 'P0000GL41OME') that uniquely identify a location
+in the Precisely data platform. Use this tool when you already have a Precisely key obtained
+from a prior call like geocode, ogc_collection_items, others.
+Do NOT use if you only have a human-readable address — use geocode instead.
+Supports batch lookup of multiple keys in a single call.
+
+Output: Array of full address records (one per key), each containing standardized address components, coordinates, and associated metadata.""",
             inputSchema={
                 "type": "object",
                 "properties": {
@@ -257,61 +227,45 @@ def get_tools() -> list[Tool]:
             }
         ),
         Tool(
-            name="parse_address",
-            description=(
-                "Parse a single free-text address string into its individual structural components: "
-                "house number, street name, street type, unit, city, state, postal code, and country. "
-                "Use this tool when you need to decompose an address into parts for data processing or validation. "
-                "Do NOT use if you need coordinates — use geocode instead. "
-                "Do NOT use for multiple addresses in one call — use parse_address_batch instead.\n\n"
-                "Output: Object with individual address components extracted from the input string "
-                "(addressNumber, streetName, streetType, unitDesignator, unitValue, city, admin1, postalCode, country)."
-            ),
-            inputSchema={
-                "type": "object",
-                "properties": {
-                    "address": {
-                        "type": "string",
-                        "description": "Full address string to parse (e.g., '1700 District Ave #300, Burlington, MA 01803')."
-                    }
-                },
-                "required": ["address"]
-            }
-        ),
-        Tool(
-            name="parse_address_batch",
-            description=(
-                "Parse multiple free-text address strings into their individual structural components in a single batch call. "
-                "Each address is decomposed into house number, street name, street type, unit, city, state, postal code, and country. "
-                "Use this tool when you have two or more addresses to parse (more efficient than repeated parse_address calls). "
-                "Do NOT use for a single address — use parse_address instead. "
-                "Maximum batch size: 10 addresses per call.\n\n"
-                "Output: Array of parsed address objects (one per input), each with individual components "
-                "(addressNumber, streetName, streetType, unitDesignator, city, admin1, postalCode, country). "
-                "Each result includes the 'id' field from the corresponding input for correlation."
-            ),
+            name="parse_addresses",
+            description="""Parse one or more free-text address strings into their individual structural components:
+address number, street, unit, city, postal code, and country. Accepts a single address string
+or an array of address objects (max 10). A single string is automatically handled as a one-item batch.
+Use this tool when you need to decompose addresses into parts for data processing or validation.
+Do NOT use if you need coordinates — use geocode instead.
+
+Output: Array of parsed address objects (one per input), each with individual components. Each result includes the 'id' field from the corresponding input for correlation when provided.""",
             inputSchema={
                 "type": "object",
                 "properties": {
                     "addresses": {
-                        "type": "array",
-                        "description": "List of address strings to parse. Maximum 10 per call.",
-                        "items": {
-                            "type": "object",
-                            "properties": {
-                                "id": {
-                                    "type": "string",
-                                    "description": "Client-supplied identifier to correlate this input with its output (e.g., '1')."
-                                },
-                                "address": {
-                                    "type": "string",
-                                    "description": "Full address string to parse (e.g., '123 Main St, Boston, MA 02101')."
-                                }
+                        "description": "Address(es) to parse. Provide a single address string or an array of address objects (max 10).",
+                        "oneOf": [
+                            {
+                                "type": "string",
+                                "description": "A single address string to parse (e.g., '1700 District Ave #300, Burlington, MA 01803')."
                             },
-                            "required": ["address"]
-                        },
-                        "minItems": 1,
-                        "maxItems": 10
+                            {
+                                "type": "array",
+                                "description": "List of address objects to parse. Maximum 10 per call.",
+                                "items": {
+                                    "type": "object",
+                                    "properties": {
+                                        "id": {
+                                            "type": "string",
+                                            "description": "Client-supplied identifier to correlate this input with its output (e.g., '1')."
+                                        },
+                                        "address": {
+                                            "type": "string",
+                                            "description": "Full address string to parse (e.g., '123 Main St, Boston, MA 02101')."
+                                        }
+                                    },
+                                    "required": ["address"]
+                                },
+                                "minItems": 1,
+                                "maxItems": 10
+                            }
+                        ]
                     }
                 },
                 "required": ["addresses"]

--- a/dis-locate-apis-v2/mcp_servers/tools/geolocation.py
+++ b/dis-locate-apis-v2/mcp_servers/tools/geolocation.py
@@ -11,19 +11,16 @@ def get_tools() -> list[Tool]:
     return [
         Tool(
             name="geo_locate_ip_address",
-            description=(
-                "Resolve the approximate geographic location (city-level) of a device or network "
-                "from its public IP address. "
-                "Returns country, region, city, postal code, and approximate latitude/longitude. "
-                "Use this tool when you have a public IPv4 or IPv6 address and need to infer its physical location. "
-                "Do NOT use for precise location — IP geolocation is approximate (city-level accuracy at best) "
-                "and should not be used as a substitute for GPS or address-based geocoding. "
-                "Do NOT use with private/reserved IP addresses (e.g., 192.168.x.x, 10.x.x.x, 127.0.0.1) — "
-                "those will not resolve to a meaningful location. "
-                "For WiFi-based location, use geo_locate_wifi_access_point instead.\n\n"
-                "Output: Object with country, region/state, city, postal code, approximate latitude/longitude, "
-                "and ISP information for the given IP address."
-            ),
+            description="""Resolve the approximate geographic location (city-level) of a device or network from its
+public IP address. Returns country, region, city, postal code, and approximate latitude/longitude.
+Use this tool when you have a public IPv4 or IPv6 address and need to infer its physical location.
+Do NOT use for precise location — IP geolocation is approximate (city-level accuracy at best)
+and should not be used as a substitute for GPS or address-based geocoding.
+Do NOT use with private/reserved IP addresses (e.g., 192.168.x.x, 10.x.x.x, 127.0.0.1) —
+those will not resolve to a meaningful location.
+For WiFi-based location, use geo_locate_wifi_access_point instead.
+
+Output: Object with country, region/state, city, postal code, approximate latitude/longitude, and ISP information for the given IP address.""",
             inputSchema={
                 "type": "object",
                 "properties": {
@@ -40,17 +37,15 @@ def get_tools() -> list[Tool]:
         ),
         Tool(
             name="geo_locate_wifi_access_point",
-            description=(
-                "Resolve the geographic location of a device from nearby WiFi access point signal data. "
-                "Returns latitude, longitude, and accuracy radius based on the MAC address, optionally signal strength "
-                "of the observed WiFi access point(s). "
-                "Use this tool when you have WiFi scanning data (MAC address, signal strength) "
-                "and need to determine physical location without GPS. "
-                "Do NOT use if you have an IP address — use geo_locate_ip_address instead. "
-                "Do NOT use if you have a street address — use geocode instead. "
-                "Output: Object with latitude, longitude, and accuracy radius (in meters) "
-                "for the resolved location of the WiFi access point."
-            ),
+            description="""Resolve the geographic location of a device from nearby WiFi access point signal data.
+Returns latitude, longitude, and accuracy radius based on the MAC address, optionally signal
+strength of the observed WiFi access point(s). Use this tool when you have WiFi scanning data
+(MAC address, signal strength) and need to determine physical location without GPS.
+Do NOT use if you have an IP address — use geo_locate_ip_address instead.
+Do NOT use if you have a street address — use geocode instead.
+
+Output: Object with latitude, longitude, and accuracy radius (in meters) for the resolved
+location of the WiFi access point.""",
             inputSchema={
                 "type": "object",
                 "properties": {

--- a/dis-locate-apis-v2/mcp_servers/tools/graphql_services.py
+++ b/dis-locate-apis-v2/mcp_servers/tools/graphql_services.py
@@ -44,291 +44,267 @@ def get_tools() -> list[Tool]:
     # Property & Risk tools (9 tools)
     Tool(
         name="get_property_data",
-        description=(
-            "Retrieve a comprehensive consolidated property record for a US address, including "
-            "property attributes (size, year built, bedrooms, bathrooms), "
-            "assessed/market value, building characteristics. "
-            "Use this tool when you need a broad property overview in a single call. "
-            "Do NOT use if you only need specific attribute categories — "
-            "use get_property_attributes_by_address (physical attributes only), "
-            "get_replacement_cost_by_address (replacement cost only), "
-            "get_buildings_by_address (building footprint/structure only), or "
-            "get_parcels_by_address (parcel/land data only) for narrower, faster responses. "
-            "Only works for US addresses.\n\n"
-            "Output: Comprehensive property record with attributes, valuation, "
-            "building characteristics."
-        ),
+        description="""Retrieve a comprehensive consolidated property record for a US address, including property
+attributes (size, year built, bedrooms, bathrooms), assessed/market value, building characteristics.
+Use this tool when you need a broad property overview in a single call.
+Do NOT use if you only need specific attribute categories — use
+get_property_attributes_by_address (physical attributes only),
+get_replacement_cost_by_address (replacement cost only),
+get_buildings_by_address (building footprint/structure only), or
+get_parcels_by_address (parcel/land data only) for narrower, faster responses.
+Only works for US addresses.
+
+Output: Comprehensive property record with attributes, valuation, building characteristics.""",
         inputSchema=_ADDRESS_INPUT_SCHEMA
     ),
     Tool(
         name="get_property_attributes_by_address",
-        description=(
-            "Retrieve physical property attributes for a US address: "
-            "bedrooms, bathrooms, square footage, lot size, year built. "
-            "Use this tool when you specifically need physical/structural property attributes. "
-            "Do NOT use if you need a full property overview — use get_property_data instead. "
-            "Do NOT use for valuation data — use get_replacement_cost_by_address instead. "
-            "Do NOT use for risk assessments — use the specific risk tools (get_flood_risk_by_address, etc.). "
-            "Only works for US addresses.\n\n"
-            "Output: Object with physical property attributes including bedroom/bathroom counts, "
-            "square footage, lot size, year built."
-        ),
+        description="""Retrieve physical property attributes for a US address: bedrooms, bathrooms, square footage,
+lot size, year built.
+Do NOT use if you need a full property overview — use get_property_data instead.
+Do NOT use for valuation data — use get_replacement_cost_by_address instead.
+Do NOT use for risk assessments — use the specific risk tools (get_flood_risk_by_address, etc.).
+Only works for US addresses.
+
+Output: Object with physical property attributes including bedroom/bathroom counts, square
+footage, lot size, year built.""",
         inputSchema=_ADDRESS_INPUT_SCHEMA
     ),
     Tool(
         name="get_replacement_cost_by_address",
-        description=(
-            "Retrieve the estimated replacement cost (cost to rebuild) for a property at a US address, "
-            "including a confidence code. "
-            "Do NOT use if you need general property attributes — use get_property_attributes_by_address instead. "
-            "Do NOT use if you need market/assessed value — replacement cost only reflects reconstruction cost. "
-            "Only works for US addresses.\n\n"
-            "Output: Object with estimated replacement cost value and confidence code."
-        ),
+        description="""Retrieve the estimated replacement cost (cost to rebuild) for a property at a US address,
+including a confidence code.
+Do NOT use if you need general property attributes — use get_property_attributes_by_address instead.
+Do NOT use if you need market/assessed value — replacement cost only reflects reconstruction cost.
+Only works for US addresses.
+
+Output: Object with estimated replacement cost value and confidence code.""",
         inputSchema=_ADDRESS_INPUT_SCHEMA
     ),
     Tool(
         name="get_flood_risk_by_address",
-        description=(
-            "Retrieve flood risk assessment data for a US address, including FEMA flood zone classification, "
-            "map effective and revision dates, and other risk indicators. "
-            "Use this tool when you need to assess flood exposure for a property. "
-            "Do NOT use if you need wildfire, fire, earthquake, coastal, or weather risk — "
-            "use the corresponding specific risk tool instead. "
-            "Only works for US addresses.\n\n"
-            "Output: Object with FEMA flood zone code and other risk indicators like "
-            "address elevation, distances to 100-year and 500-year flood zones, elevation profile "
-            "to nearest waterbody, distance to nearest waterbody."
-        ),
+        description="""Retrieve flood risk assessment data for a US address, including FEMA flood zone classification,
+map effective and revision dates, and other risk indicators.
+Use this tool when you need to assess flood exposure for a property.
+Do NOT use if you need wildfire, fire, earthquake, coastal, or weather risk —
+use the corresponding specific risk tool instead.
+Only works for US addresses.
+
+Output: Object with FEMA flood zone code, address elevation, distances to 100-year and
+500-year flood zones, elevation profile to nearest waterbody, distance to nearest waterbody.""",
         inputSchema=_ADDRESS_INPUT_SCHEMA
     ),
     Tool(
         name="get_wildfire_risk_by_address",
-        description=(
-            "Retrieve wildfire risk assessment data for a US address, "
-            "including risk rankings, risk description, and other contributing factor ratings. "
-            "Use this tool when you need to assess wildfire exposure for a property. "
-            "Do NOT use if you need flood, fire (structural), earthquake, coastal, or weather risk — "
-            "use the corresponding specific risk tool instead. "
-            "Only works for US addresses.\n\n"
-            "Output: Object with overall risk ranking, risk description for both baseline and extreme "
-            "models, individual component ratings (severity, frequency, damage, community, vegetation, "
-            "burn probability, ember risk, proximity factors, etc.) for each model, wildland-urban interface "
-            "distance, distances to high/very-high/extreme risk zones, and nearest historical fire perimeter details."
-        ),
+        description="""Retrieve wildfire risk assessment data for a US address, including risk rankings, risk
+description, and other contributing factor ratings.
+Use this tool when you need to assess wildfire exposure for a property.
+Do NOT use if you need flood, fire (structural), earthquake, coastal, or weather risk —
+use the corresponding specific risk tool instead.
+Only works for US addresses.
+
+Output: Object with overall risk ranking, risk description for both baseline and extreme
+models, individual component ratings (severity, frequency, damage, community, vegetation,
+burn probability, ember risk, proximity factors, etc.) for each model, wildland-urban interface
+distance, distances to high/very-high/extreme risk zones, and nearest historical fire
+perimeter details.""",
         inputSchema=_ADDRESS_INPUT_SCHEMA
     ),
     Tool(
         name="get_property_fire_risk",
-        description=(
-            "Retrieve fire station proximity data for a US address, "
-            "including response time and distance data for the three nearest fire stations. "
-            "This tool covers fire department proximity and response times — not wildfire risk. "
-            "Use this tool when you need to assess fire station coverage for a property. "
-            "Do NOT use if you need wildfire risk — use get_wildfire_risk_by_address instead. "
-            "Do NOT use if you need flood, earthquake, coastal, or weather risk. "
-            "Only works for US addresses.\n\n"
-            "Output: Object with ID, type, drive times, and drive distance for each of the three "
-            "nearest fire stations. Also includes distance to nearest water body in feet."
-        ),
+        description="""Retrieve fire station proximity data for a US address, including response time and distance
+data for the three nearest fire stations. This tool covers fire department proximity and
+response times — not wildfire risk.
+Do NOT use if you need wildfire risk — use get_wildfire_risk_by_address instead.
+Do NOT use if you need flood, earthquake, coastal, or weather risk.
+Only works for US addresses.
+
+Output: Object with ID, type, drive times, and drive distance for each of the three nearest
+fire stations. Also includes distance to nearest water body in feet.""",
         inputSchema=_ADDRESS_INPUT_SCHEMA
     ),
     Tool(
         name="get_earth_risk",
-        description=(
-            "Retrieve earthquake risk data for a US address, including historical earthquake "
-            "event counts, nearest fault details, and seismic site classification. "
-            "Use this tool when you need to assess earthquake/seismic exposure for a property. "
-            "Do NOT use if you need flood, wildfire, fire (structural), coastal, or weather risk — "
-            "use the corresponding specific risk tool instead. "
-            "Only works for US addresses.\n\n"
-            "Output: Object with historical earthquake event counts by magnitude level, "
-            "nearest fault distance, type, age etc., and NEHRP site classification and code."
-        ),
+        description="""Retrieve earthquake risk data for a US address, including historical earthquake event counts,
+nearest fault details, and seismic site classification.
+Use this tool when you need to assess earthquake/seismic exposure for a property.
+Do NOT use if you need flood, wildfire, fire (structural), coastal, or weather risk —
+use the corresponding specific risk tool instead.
+Only works for US addresses.
+
+Output: Object with historical earthquake event counts by magnitude level, nearest fault
+distance, type, age etc., and NEHRP site classification and code.""",
         inputSchema=_ADDRESS_INPUT_SCHEMA
     ),
     Tool(
         name="get_coastal_risk",
-        description=(
-            "Retrieve coastal wind and hurricane risk data for a US address, including proximity "
-            "to coastline, wind pool territory, and hurricane wind speed/debris classifications. "
-            "Use this tool for properties near coastlines where hurricane or coastal wind risk is relevant. "
-            "Do NOT use if you need flood zone (FEMA) risk — use get_flood_risk_by_address instead. "
-            "Do NOT use if you need wildfire, earthquake, structural fire, or weather risk. "
-            "Only works for US addresses.\n\n"
-            "Output: Object with distance to nearest coastline, nearest waterbody, adjacent "
-            "waterbody, wind pool description, and hurricane wind speeds, and wind-borne debris "
-            "zone classifications."
-        ),
+        description="""Retrieve coastal wind and hurricane risk data for a US address, including proximity to
+coastline, wind pool territory, and hurricane wind speed/debris classifications.
+Use this tool for properties near coastlines where hurricane or coastal wind risk is relevant.
+Do NOT use if you need flood zone (FEMA) risk — use get_flood_risk_by_address instead.
+Do NOT use if you need wildfire, earthquake, structural fire, or weather risk.
+Only works for US addresses.
+
+Output: Object with distance to nearest coastline, nearest waterbody, adjacent waterbody,
+wind pool description, hurricane wind speeds, and wind-borne debris zone classifications.""",
         inputSchema=_ADDRESS_INPUT_SCHEMA
     ),
     Tool(
         name="get_historical_weather_risk",
-        description=(
-            "Retrieve historical weather risk data for a US address, including exposure to "
-            "severe weather events such as hail, wind, tornado, and hurricane. "
-            "Use this tool when you need historical weather hazard information for insurance, "
-            "underwriting, or risk profiling. "
-            "Do NOT use for flood, wildfire, earthquake, fire protection class, or coastal risk "
-            "— use the corresponding specific risk tools instead. "
-            "Only works for US addresses.\n\n"
-            "Output: Object with risk level classifications for hail, tornado, wind, and "
-            "hurricane event count and range."
-        ),
+        description="""Retrieve historical weather risk data for a US address, including exposure to severe weather
+events such as hail, wind, tornado, and hurricane.
+Use this tool when you need historical weather hazard information for insurance, underwriting,
+or risk profiling.
+Do NOT use for flood, wildfire, earthquake, fire protection class, or coastal risk —
+use the corresponding specific risk tools instead.
+Only works for US addresses.
+
+Output: Object with risk level classifications for hail, tornado, wind, and hurricane event
+count and range.""",
         inputSchema=_ADDRESS_INPUT_SCHEMA
     ),
 
     # Demographics & Neighborhoods tools (8 tools)
     Tool(
         name="get_demographics",
-        description=(
-            "Retrieve a combined demographic profile for a US address, "
-            "including both PSYTE geodemographic segmentation and Ground View census demographics. "
-            "Returns lifestyle segment classification and key census block group statistics. "
-            "Use this tool when you need a broad demographic overview combining both PSYTE and Ground View datasets. "
-            "Do NOT use if you only need PSYTE segmentation — use get_psyte_geodemographics_by_address instead. "
-            "Do NOT use if you only need Ground View statistics — use get_ground_view_by_address instead. "
-            "Do NOT use for crime index, neighborhood names, school data, building, or parcel data. "
-            "Only works for US addresses.\n\n"
-            "Output: Object with PSYTE segment code and description, household income, property value, "
-            "adult age, household composition variables from PSYTE, census block group statistics "
-            "like average household income, education percentages, average home value, rent."
-        ),
+        description="""Retrieve a combined demographic profile for a US address, including both PSYTE geodemographic
+segmentation and Ground View census demographics. Returns lifestyle segment classification and
+key census block group statistics.
+Use this tool when you need a broad demographic overview combining both PSYTE and Ground View datasets.
+Do NOT use if you only need PSYTE segmentation — use get_psyte_geodemographics_by_address instead.
+Do NOT use if you only need Ground View statistics — use get_ground_view_by_address instead.
+Do NOT use for crime index, neighborhood names, school data, building, or parcel data.
+Only works for US addresses.
+
+Output: Object with PSYTE segment code and description, household income, property value,
+adult age, household composition variables from PSYTE, census block group statistics like
+average household income, education percentages, average home value, rent.""",
         inputSchema=_ADDRESS_INPUT_SCHEMA
     ),
     Tool(
         name="get_crime_index",
-        description=(
-            "Retrieve national crime index values for a US address, including overall composite, "
-            "violent crime and property crime, and their respective level and descriptions. "
-            "Use this tool when you need to assess crime risk for a location. "
-            "Do NOT use for weather, flood, fire, earthquake, wildfire, or coastal risk — "
-            "use the specific risk tools. "
-            "Do NOT use for demographic segmentation — use get_demographics or the specific"
-            " PSYTE/Ground View tools. "
-            "Only works for US addresses.\n\n"
-            "Output: Object with composite, violent crime, and property crime national index values, "
-            "and categories, descriptions for each."
-        ),
+        description="""Retrieve national crime index values for a US address, including overall composite, violent
+crime and property crime, and their respective level and descriptions.
+Use this tool when you need to assess crime risk for a location.
+Do NOT use for weather, flood, fire, earthquake, wildfire, or coastal risk —
+use the specific risk tools.
+Do NOT use for demographic segmentation — use get_demographics or the specific PSYTE/Ground View tools.
+Only works for US addresses.
+
+Output: Object with composite, violent crime, and property crime national index values,
+and categories, descriptions for each.""",
         inputSchema=_ADDRESS_INPUT_SCHEMA
     ),
     Tool(
         name="get_psyte_geodemographics_by_address",
-        description=(
-            "Retrieve PSYTE geodemographic segment classification for a US address. "
-            "PSYTE (a Precisely proprietary segmentation system) classifies neighborhoods into lifestyle and "
-            "demographic segments based on income, age, household composition, and lifestyle factors. "
-            "Use this tool when you specifically need PSYTE segment data for targeting, analysis, or profiling. "
-            "Do NOT use if you also need Ground View market segment data — use get_demographics instead "
-            "(returns both PSYTE and Ground View in one call). "
-            "Do NOT use for crime, risk, building, parcel, or school data. "
-            "Only works for US addresses.\n\n"
-            "Output: Object with PSYTE segment code, segment name, segment group, "
-            "and demographic characteristics for the neighborhood of the input address."
-        ),
+        description="""Retrieve PSYTE geodemographic segment classification for a US address. PSYTE (a Precisely
+proprietary segmentation system) classifies neighborhoods into lifestyle and demographic
+segments based on income, age, household composition, and lifestyle factors.
+Use this tool when you specifically need PSYTE segment data for targeting, analysis, or profiling.
+Do NOT use if you also need Ground View market segment data — use get_demographics instead
+(returns both PSYTE and Ground View in one call).
+Do NOT use for crime, risk, building, parcel, or school data.
+Only works for US addresses.
+
+Output: Object with PSYTE segment code, segment name, segment group, and demographic
+characteristics for the neighborhood of the input address.""",
         inputSchema=_ADDRESS_INPUT_SCHEMA
     ),
     Tool(
         name="get_ground_view_by_address",
-        description=(
-            "Retrieve Ground View census block group demographic statistics for a US address. "
-            "Ground View is a Precisely dataset providing census-derived population, housing, "
-            "education, employment, and economic statistics at the census block group level. "
-            "Use this tool when you specifically need Ground View demographic statistics. "
-            "Do NOT use if you also need PSYTE segment data — use get_demographics instead "
-            "(returns both PSYTE and Ground View in one call). "
-            "Do NOT use for crime, risk, building, parcel, or school data. "
-            "Only works for US addresses.\n\n"
-            "Output: Object with census block group demographic statistics including population "
-            "age distribution percentages, marital status percentages, education percentages, "
-            "unemployment rate, owner/renter occupied percentages), average vehicles per household, "
-            "average rent, average home value, and average household income."
-        ),
+        description="""Retrieve Ground View census block group demographic statistics for a US address. Ground View
+is a Precisely dataset providing census-derived population, housing, education, employment,
+and economic statistics at the census block group level.
+Use this tool when you specifically need Ground View demographic statistics.
+Do NOT use if you also need PSYTE segment data — use get_demographics instead
+(returns both PSYTE and Ground View in one call).
+Do NOT use for crime, risk, building, parcel, or school data.
+Only works for US addresses.
+
+Output: Object with census block group demographic statistics including population age
+distribution percentages, marital status percentages, education percentages, unemployment
+rate, owner/renter occupied percentages, average vehicles per household, average rent,
+average home value, and average household income.""",
         inputSchema=_ADDRESS_INPUT_SCHEMA
     ),
     Tool(
         name="get_neighborhoods_by_address",
-        description=(
-            "Retrieve neighborhood profile data for a US address, including neighborhood name, "
-            "walkability/mobility scores, and real estate market characteristics. "
-            "Use this tool when you need neighborhood-level data including mobility scores, "
-            "property prices, sales trends, or property type breakdown. "
-            "Do NOT use for demographic data — use get_demographics or PSYTE/Ground View tools instead. "
-            "Do NOT use for school, building, parcel, or crime data. "
-            "Only works for US addresses.\n\n"
-            "Output: Object with neighborhood name and ID, walkability/bike/transit/drive scores, "
-            "average single-family residence price and sales trend direction, average property year built, "
-            "bedrooms, bathrooms, living square footage, lot size, pool percentage, single-family residence "
-            "percentage, and counts of commercial, single-family, condo, duplex, and apartment properties."
-        ),
+        description="""Retrieve neighborhood profile data for a US address, including neighborhood name,
+walkability/mobility scores, and real estate market characteristics.
+Use this tool when you need neighborhood-level data including mobility scores, property prices,
+sales trends, or property type breakdown.
+Do NOT use for demographic data — use get_demographics or PSYTE/Ground View tools instead.
+Do NOT use for school, building, parcel, or crime data.
+Only works for US addresses.
+
+Output: Object with neighborhood name and ID, walkability/bike/transit/drive scores, average
+single-family residence price and sales trend direction, average property year built, bedrooms,
+bathrooms, living square footage, lot size, pool percentage, single-family residence percentage,
+and counts of commercial, single-family, condo, duplex, and apartment properties.""",
         inputSchema=_ADDRESS_INPUT_SCHEMA
     ),
     Tool(
         name="get_schools_by_address",
-        description=(
-            "Retrieve school district, attendance zone, and nearby college information for a US address. "
-            "Use this tool when you need to identify which schools and districts serve an address. "
-            "Do NOT use for demographic, crime, risk, building, or parcel data. "
-            "Only works for US addresses.\n\n"
-            "Output: Object with three sections: nearby college/university (ID and name), "
-            "schoolDistrict (district ID and name), and schoolAttendanceZone (ID and "
-            "name, where names identify the assigned K-12 schools). "
-            "Note: individual school type, enrollment count, grade range, and distance to school are not returned."
-        ),
+        description="""Retrieve school district, attendance zone, and nearby college information for a US address.
+Use this tool when you need to identify which schools and districts serve an address.
+Do NOT use for demographic, crime, risk, building, or parcel data.
+Only works for US addresses.
+
+Output: Object with three sections: nearby college/university (ID and name), schoolDistrict
+(district ID and name), and schoolAttendanceZone (ID and name, where names identify the
+assigned K-12 schools). Note: individual school type, enrollment count, grade range, and
+distance to school are not returned.""",
         inputSchema=_ADDRESS_INPUT_SCHEMA
     ),
     Tool(
         name="get_buildings_by_address",
-        description=(
-            "Retrieve building data for a US address, "
-            "including building type, area, elevation, longitude, latitude, and geography ID. "
-            "Use this tool when you need building-level data (type, area, elevation) "
-            "rather than property ownership or valuation data. "
-            "Do NOT use if you need full property data (ownership, valuation) — use get_property_data instead. "
-            "Do NOT use for parcel/land data — use get_parcels_by_address instead. "
-            "Only works for US addresses.\n\n"
-            "Output: Object with building ID, UBID (universal building ID), building type "
-            "(e.g., Residential, Commercial), FIPS code, geography ID, coordinates, "
-            "elevation, and building area."
-        ),
+        description="""Retrieve building data for a US address, including building type, area, elevation, longitude,
+latitude, and geography ID.
+Use this tool when you need building-level data (type, area, elevation) rather than property
+ownership or valuation data.
+Do NOT use if you need full property data (ownership, valuation) — use get_property_data instead.
+Do NOT use for parcel/land data — use get_parcels_by_address instead.
+Only works for US addresses.
+
+Output: Object with building ID, UBID (universal building ID), building type (e.g.,
+Residential, Commercial), FIPS code, geography ID, coordinates, elevation, and building area.""",
         inputSchema=_ADDRESS_INPUT_SCHEMA
     ),
     Tool(
         name="get_parcels_by_address",
-        description=(
-            "Retrieve land parcel (lot) data for a US address, including parcel area, "
-            "APN (Assessor's Parcel Number), FIPS code, longitude, latitude, and geography ID. "
-            "Use this tool when you need parcel/lot identifiers and area "
-            "rather than building structure or property ownership information. "
-            "Do NOT use if you need full property data (ownership, valuation) — use get_property_data instead. "
-            "Do NOT use for building structure data — use get_buildings_by_address instead. "
-            "Only works for US addresses.\n\n"
-            "Output: Object with parcel ID, FIPS code, geography ID, APN, parcel area, "
-            "coordinates, and elevation for the parcel at the input address. "
-        ),
+        description="""Retrieve land parcel (lot) data for a US address, including parcel area, APN (Assessor's
+Parcel Number), FIPS code, longitude, latitude, and geography ID.
+Use this tool when you need parcel/lot identifiers and area rather than building structure
+or property ownership information.
+Do NOT use if you need full property data (ownership, valuation) — use get_property_data instead.
+Do NOT use for building structure data — use get_buildings_by_address instead.
+Only works for US addresses.
+
+Output: Object with parcel ID, FIPS code, geography ID, APN, parcel area, coordinates, and
+elevation for the parcel at the input address.""",
         inputSchema=_ADDRESS_INPUT_SCHEMA
     ),
 
     # Advanced GraphQL tools (5 tools)
     Tool(
         name="get_addresses_detailed",
-        description=(
-            "Retrieve detailed address record(s) from the Precisely address database using a custom GraphQL query. "
-            "Allows fine-grained control over which address fields to request. "
-            "Use this tool when the standard geocode or lookup tools do not return sufficient detail "
-            "and you need to construct a custom GraphQL query. "
-            "Do NOT use if a simpler tool (geocode, lookup, verify_address) already covers your need. "
-            "Only use the safe, tested fields listed below — other fields may cause 400 errors.\n\n"
-            "Safe fields for the 'addresses { data { ... } }' section:\n"
-            "  preciselyID, addressNumber, streetName, city, admin1ShortName, postalCode\n\n"
-            "Example request:\n"
-            "{'data': {\n"
-            "  'query': 'query GetAddressDetailed($address: String!, $country: String) { getByAddress(address: $address, country: $country) { addresses { data { preciselyID addressNumber streetName city admin1ShortName postalCode } } } }',\n"
-            "  'variables': {'address': '42 Valley Of The Sun Dr, Fairplay, CO 80440', 'country': 'US'}\n"
-            "}}\n\n"
-            "Output: GraphQL response with address data matching the requested fields. "
-            "Structure depends on the query provided."
-        ),
+        description="""Retrieve detailed address record(s) from the Precisely address database using a custom GraphQL
+query. Allows fine-grained control over which address fields to request.
+Use this tool when the standard geocode or lookup tools do not return sufficient detail and
+you need to construct a custom GraphQL query.
+Do NOT use if a simpler tool (geocode, lookup, verify_address) already covers your need.
+Only use the safe, tested fields listed below — other fields may cause 400 errors.
+
+Safe fields for the 'addresses { data { ... } }' section:
+  preciselyID, addressNumber, streetName, city, admin1ShortName, postalCode
+
+Example request:
+{'data': {
+  'query': 'query GetAddressDetailed($address: String!, $country: String) { getByAddress(address: $address, country: $country) { addresses { data { preciselyID addressNumber streetName city admin1ShortName postalCode } } } }',
+  'variables': {'address': '42 Valley Of The Sun Dr, Fairplay, CO 80440', 'country': 'US'}
+}}
+
+Output: GraphQL response with address data matching the requested fields. Structure depends on the query provided.""",
         inputSchema={
             "type": "object",
             "properties": {
@@ -339,30 +315,32 @@ def get_tools() -> list[Tool]:
     ),
     Tool(
         name="get_parcel_by_owner_detailed",
-        description=(
-            "Retrieve parcel records by owner via a custom GraphQL query. Supports two query modes:\n"
-            "  1. By ID: provide 'id' and 'queryType' (one of: PRECISELY_ID, PARCEL_ID, BUILDING_ID, PLACE_ID, DUNS_ID)\n"
-            "  2. By address: provide 'address' string only — do NOT pass queryType or id variables\n\n"
-            "This tool does NOT support coordinate-based lookups. "
-            "Use this tool when you need parcel ownership data and require custom field selection. "
-            "Do NOT use if get_parcels_by_address already meets your need (simpler interface). "
-            "Only use the safe, tested fields listed below.\n\n"
-            "Safe fields for the 'parcels { data { ... } }' section:\n"
-            "  parcelID, fips, geographyID, apn, parcelArea, longitude, latitude, elevation\n"
-            "Always include the metadata section: pageNumber, pageCount, totalPages, count, vintage\n\n"
-            "Example 1 — By PreciselyID (uses queryType + id):\n"
-            "{'data': {\n"
-            "  'query': 'query GetParcelByOwner($id: String, $queryType: QueryType, $address: String, $distance: Float, $limit: Int) { getParcelByOwner(id: $id, queryType: $queryType, address: $address, distance: $distance, limit: $limit) { parcels { metadata { pageNumber pageCount totalPages count vintage } data { parcelID fips geographyID apn parcelArea longitude latitude elevation } } } }',\n"
-            "  'variables': {'id': 'P0000GL41OME', 'queryType': 'PRECISELY_ID', 'address': 'Boston, MA', 'distance': 1000.0, 'limit': 50}\n"
-            "}}\n\n"
-            "Example 2 — By address (NO queryType, NO id — omit both):\n"
-            "{'data': {\n"
-            "  'query': 'query GetParcelByOwner($address: String, $distance: Float, $limit: Int) { getParcelByOwner(address: $address, distance: $distance, limit: $limit) { parcels { metadata { pageNumber pageCount totalPages count vintage } data { parcelID fips geographyID apn parcelArea longitude latitude elevation } } } }',\n"
-            "  'variables': {'address': '123 Main St, Boston, MA', 'distance': 1000.0, 'limit': 50}\n"
-            "}}\n\n"
-            "Output: GraphQL response with paginated parcel records matching the query. "
-            "Includes metadata (pageNumber, totalPages, count, vintage) and parcel data fields."
-        ),
+        description="""Retrieve parcel records by owner via a custom GraphQL query. Supports two query modes:
+  1. By ID: provide 'id' and 'queryType' (one of: PRECISELY_ID, PARCEL_ID, BUILDING_ID, PLACE_ID, DUNS_ID)
+  2. By address: provide 'address' string only — do NOT pass queryType or id variables
+
+This tool does NOT support coordinate-based lookups.
+Do NOT use if get_parcels_by_address already meets your need (simpler interface).
+Only use the safe, tested fields listed below.
+
+Safe fields for the 'parcels { data { ... } }' section:
+  parcelID, fips, geographyID, apn, parcelArea, longitude, latitude, elevation
+Always include the metadata section: pageNumber, pageCount, totalPages, count, vintage
+
+Output: GraphQL response with paginated parcel records matching the query. Includes metadata
+(pageNumber, totalPages, count, vintage) and parcel data fields.
+
+Example 1 — By PreciselyID (uses queryType + id):
+{'data': {
+  'query': 'query GetParcelByOwner($id: String, $queryType: QueryType, $address: String, $distance: Float, $limit: Int) { getParcelByOwner(id: $id, queryType: $queryType, address: $address, distance: $distance, limit: $limit) { parcels { metadata { pageNumber pageCount totalPages count vintage } data { parcelID fips geographyID apn parcelArea longitude latitude elevation } } } }',
+  'variables': {'id': 'P0000GL41OME', 'queryType': 'PRECISELY_ID', 'address': 'Boston, MA', 'distance': 1000.0, 'limit': 50}
+}}
+
+Example 2 — By address (NO queryType, NO id — omit both):
+{'data': {
+  'query': 'query GetParcelByOwner($address: String, $distance: Float, $limit: Int) { getParcelByOwner(address: $address, distance: $distance, limit: $limit) { parcels { metadata { pageNumber pageCount totalPages count vintage } data { parcelID fips geographyID apn parcelArea longitude latitude elevation } } } }',
+  'variables': {'address': '123 Main St, Boston, MA', 'distance': 1000.0, 'limit': 50}
+}}""",
         inputSchema={
             "type": "object",
             "properties": {
@@ -373,25 +351,25 @@ def get_tools() -> list[Tool]:
     ),
     Tool(
         name="get_address_family",
-        description=(
-            "Retrieve all addresses associated with the same property or parcel as a given PreciselyID, "
-            "via a custom GraphQL query. "
-            "Address families include all delivery points sharing a parent location "
-            "(e.g., all units in a multi-unit building). "
-            "Use this tool when you have a PreciselyID and need to enumerate all related addresses at that property. "
-            "Requires queryType = 'PRECISELY_ID'. "
-            "Do NOT use with ADDRESS or LOCATION query types — this tool only supports PRECISELY_ID.\n\n"
-            "Safe fields for the 'addressFamily { data { ... } }' section:\n"
-            "  preciselyID, addressNumber, streetName, city, admin1ShortName, postalCode\n"
-            "Always include the metadata section: pageNumber, pageCount, totalPages, count, vintage\n\n"
-            "Example request:\n"
-            "{'data': {\n"
-            "  'query': 'query GetAddressFamily($id: String!, $queryType: QueryType!) { getById(id: $id, queryType: $queryType) { addresses { data { preciselyID addressFamily(pageNumber: 1, pageSize: 20) { metadata { pageNumber pageCount totalPages count vintage } data { preciselyID addressNumber streetName city admin1ShortName postalCode } } } } } }',\n"
-            "  'variables': {'id': 'P0000GL41OME', 'queryType': 'PRECISELY_ID'}\n"
-            "}}\n\n"
-            "Output: GraphQL response with paginated list of related address records "
-            "sharing the same parent property, with pagination metadata."
-        ),
+        description="""Retrieve all addresses associated with the same property or parcel as a given PreciselyID,
+via a custom GraphQL query. Address families include all delivery points sharing a parent
+location (e.g., all units in a multi-unit building).
+Use this tool when you have a PreciselyID and need to enumerate all related addresses at
+that property. Requires queryType = 'PRECISELY_ID'.
+Do NOT use with ADDRESS or LOCATION query types — this tool only supports PRECISELY_ID.
+
+Safe fields for the 'addressFamily { data { ... } }' section:
+  preciselyID, addressNumber, streetName, city, admin1ShortName, postalCode
+Always include the metadata section: pageNumber, pageCount, totalPages, count, vintage
+
+Output: GraphQL response with paginated list of related address records sharing the same
+parent property, with pagination metadata.
+
+Example request:
+{'data': {
+  'query': 'query GetAddressFamily($id: String!, $queryType: QueryType!) { getById(id: $id, queryType: $queryType) { addresses { data { preciselyID addressFamily(pageNumber: 1, pageSize: 20) { metadata { pageNumber pageCount totalPages count vintage } data { preciselyID addressNumber streetName city admin1ShortName postalCode } } } } } }',
+  'variables': {'id': 'P0000GL41OME', 'queryType': 'PRECISELY_ID'}
+}}""",
         inputSchema={
             "type": "object",
             "properties": {
@@ -402,24 +380,24 @@ def get_tools() -> list[Tool]:
     ),
     Tool(
         name="get_serviceability",
-        description=(
-            "Retrieve broadband and utility serviceability information for a US address using a custom GraphQL query. "
-            "Returns whether broadband or utility services are available at the address "
-            "and the associated service provider records. "
-            "Use this tool when you need to check broadband/utility service availability at a property. "
-            "Only use the safe, tested fields listed below.\n\n"
-            "Safe fields for the 'serviceability { data { ... } }' section:\n"
-            "  serviceabilityID, preciselyID, serviceableAddress\n"
-            "Always include the metadata section: pageNumber, pageCount, totalPages, count, vintage\n\n"
-            "Example request:\n"
-            "{'data': {\n"
-            "  'query': 'query GetServiceability($address: String!, $country: String) { getByAddress(address: $address, country: $country) { addresses(pageNumber: 1, pageSize: 1) { data { preciselyID serviceability { metadata { pageNumber pageCount totalPages count vintage } data { serviceabilityID preciselyID serviceableAddress } } } } } }',\n"
-            "  'variables': {'address': '2755 Milwaukee St, Denver, 80238 CO', 'country': 'US'}\n"
-            "}}\n\n"
-            "Output: GraphQL response with serviceability records containing serviceabilityID, "
-            "preciselyID, and a serviceableAddress flag ('YES'/'NO') indicating whether "
-            "the address is serviceable."
-        ),
+        description="""Retrieve broadband and utility serviceability information for a US address using a custom
+GraphQL query. Returns whether broadband or utility services are available at the address
+and the associated service provider records.
+Use this tool when you need to check broadband/utility service availability at a property.
+Only use the safe, tested fields listed below.
+
+Safe fields for the 'serviceability { data { ... } }' section:
+  serviceabilityID, preciselyID, serviceableAddress
+Always include the metadata section: pageNumber, pageCount, totalPages, count, vintage
+
+Output: GraphQL response with serviceability records containing serviceabilityID, preciselyID,
+and a serviceableAddress flag ('YES'/'NO') indicating whether the address is serviceable.
+
+Example request:
+{'data': {
+  'query': 'query GetServiceability($address: String!, $country: String) { getByAddress(address: $address, country: $country) { addresses(pageNumber: 1, pageSize: 1) { data { preciselyID serviceability { metadata { pageNumber pageCount totalPages count vintage } data { serviceabilityID preciselyID serviceableAddress } } } } } }',
+  'variables': {'address': '2755 Milwaukee St, Denver, 80238 CO', 'country': 'US'}
+}}""",
         inputSchema={
             "type": "object",
             "properties": {
@@ -430,31 +408,33 @@ def get_tools() -> list[Tool]:
     ),
     Tool(
         name="get_places_by_address",
-        description=(
-            "Retrieve points of interest (POI) / businesses at or near a US address using a custom GraphQL query. "
-            "Returns business names, industry codes, contact information, and location data "
-            "for places associated with the address. "
-            "Use this tool when you need business/POI data at a given address. "
-            "Do NOT use for property, parcel, building, or risk data — use the appropriate property/risk tools instead.\n\n"
-            "Available fields in the 'places { data { ... } }' section:\n"
-            "  Identity: PBID, pointOfInterestID, preciselyID, parentPreciselyID\n"
-            "  Business: businessName, brandName, tradeName, franchiseName\n"
-            "  Location: countryIsoAlpha3Code, localityName, city, admin2, admin1, admin1ShortName\n"
-            "  Address: addressNumber, streetName, postalCode, formattedAddress, addressLine1, addressLine2\n"
-            "  Coordinates: longitude, latitude\n"
-            "  Georesult: georesult { value description }, georesultConfidence { value description }\n"
-            "  Contact: countryCallingCode, phone, fax, email, web\n"
-            "  Hours: open24Hours { value description }\n"
-            "  Industry: lineOfBusiness, sic1, sic2, sic8, sic8Description, altIndustryCode { value description }, miCode, tradeDivision, groupName, mainClass, subClass\n"
-            "Always include the metadata section: pageNumber, pageCount, totalPages, count, vintage\n\n"
-            "Example request:\n"
-            "{'data': {\n"
-            "  'query': 'query GetPlacesByAddress($address: String!, $country: String) { getByAddress(address: $address, country: $country) { places(pageNumber: 1, pageSize: 20) { metadata { pageNumber pageCount totalPages count vintage } data { PBID pointOfInterestID preciselyID parentPreciselyID businessName brandName tradeName franchiseName countryIsoAlpha3Code localityName city admin2 admin1 admin1ShortName addressNumber streetName postalCode formattedAddress addressLine1 addressLine2 longitude latitude georesult { value description } georesultConfidence { value description } countryCallingCode phone fax email web open24Hours { value description } lineOfBusiness sic1 sic2 sic8 sic8Description altIndustryCode { value description } miCode tradeDivision groupName mainClass subClass } } } }',\n"
-            "  'variables': {'address': '123 Main St, Boston, MA 02101', 'country': 'US'}\n"
-            "}}\n\n"
-            "Output: GraphQL response with paginated place/POI records "
-            "matching the address, with business details and pagination metadata."
-        ),
+        description="""Retrieve points of interest (POI) / businesses at or near a US address using a custom GraphQL
+query. Returns business names, industry codes, contact information, and location data for
+places associated with the address.
+Use this tool when you need business/POI data at a given address.
+Do NOT use for property, parcel, building, or risk data — use the appropriate property/risk
+tools instead.
+
+Available fields in the 'places { data { ... } }' section:
+  Identity: PBID, pointOfInterestID, preciselyID, parentPreciselyID
+  Business: businessName, brandName, tradeName, franchiseName
+  Location: countryIsoAlpha3Code, localityName, city, admin2, admin1, admin1ShortName
+  Address: addressNumber, streetName, postalCode, formattedAddress, addressLine1, addressLine2
+  Coordinates: longitude, latitude
+  Georesult: georesult { value description }, georesultConfidence { value description }
+  Contact: countryCallingCode, phone, fax, email, web
+  Hours: open24Hours { value description }
+  Industry: lineOfBusiness, sic1, sic2, sic8, sic8Description, altIndustryCode { value description }, miCode, tradeDivision, groupName, mainClass, subClass
+Always include the metadata section: pageNumber, pageCount, totalPages, count, vintage
+
+Output: GraphQL response with paginated place/POI records matching the address, with business
+details and pagination metadata.
+
+Example request:
+{'data': {
+  'query': 'query GetPlacesByAddress($address: String!, $country: String) { getByAddress(address: $address, country: $country) { places(pageNumber: 1, pageSize: 20) { metadata { pageNumber pageCount totalPages count vintage } data { PBID pointOfInterestID preciselyID parentPreciselyID businessName brandName tradeName franchiseName countryIsoAlpha3Code localityName city admin2 admin1 admin1ShortName addressNumber streetName postalCode formattedAddress addressLine1 addressLine2 longitude latitude georesult { value description } georesultConfidence { value description } countryCallingCode phone fax email web open24Hours { value description } lineOfBusiness sic1 sic2 sic8 sic8Description altIndustryCode { value description } miCode tradeDivision groupName mainClass subClass } } } }',
+  'variables': {'address': '123 Main St, Boston, MA 02101', 'country': 'US'}
+}}""",
         inputSchema={
             "type": "object",
             "properties": {

--- a/dis-locate-apis-v2/mcp_servers/tools/map_services.py
+++ b/dis-locate-apis-v2/mcp_servers/tools/map_services.py
@@ -1,6 +1,6 @@
 """
 Map Services Tools Module
-Contains 15 tools for WMS, WMTS, and OGC Features APIs
+Contains 8 tools for WMS, WMTS, and OGC Features APIs
 """
 from typing import List, Dict, Any
 from mcp.types import Tool, TextContent, ImageContent, CallToolResult
@@ -13,38 +13,6 @@ logger = get_logger(__name__)
 def get_tools() -> list[Tool]:
     """Returns list of map services tool definitions"""
     return [
-        Tool(
-        name="ogc_landing_page",
-        description="""Discovery tool: retrieve the OGC API landing page with links to essential API resources.
-Provides links to the API definition, conformance declaration, and feature collections.
-Use this as the entry point to navigate and explore OGC API capabilities.
-Call this first if you have no other OGC resource URLs and need to discover what is available.
-
-Returns: Object with links array (API definition, conformance, feature collections).
-
-Example Request: https://api.cloud.precisely.com/v1/ogcapi/enrich/""",
-        inputSchema={
-            "type": "object",
-            "properties": {},
-            "required": []
-        }
-    ),
-    Tool(
-        name="ogc_api_definition",
-        description="""Discovery tool: retrieve the full OpenAPI 3.0.1 specification for the OGC Enrich API.
-The specification describes all available endpoints, request/response schemas, and security configurations.
-Use this when you need to inspect full API capabilities programmatically.
-Do NOT use for listing feature collections — use ogc_collections instead.
-
-Returns: OpenAPI 3.0.1 specification document.
-
-Example Request: https://api.cloud.precisely.com/v1/ogcapi/enrich/api""",
-        inputSchema={
-            "type": "object",
-            "properties": {},
-            "required": []
-        }
-    ),
     Tool(
         name="ogc_functions",
         description="""Discovery tool: retrieve a list of available spatial functions within the OGC Enrich API.
@@ -61,26 +29,11 @@ Example Request: https://api.cloud.precisely.com/v1/ogcapi/enrich/functions""",
         }
     ),
     Tool(
-        name="ogc_conformance",
-        description="""Discovery tool: retrieve the conformance declaration listing all OGC API standards this server conforms to.
-Use this to verify whether the API supports specific OGC standards required by your client.
-Do NOT use to discover feature collections — use ogc_collections instead.
-
-Returns: Conformance declaration with a list of conformance class URIs.
-
-Example Request: https://api.cloud.precisely.com/v1/ogcapi/enrich/conformance""",
-        inputSchema={
-            "type": "object",
-            "properties": {},
-            "required": []
-        }
-    ),
-    Tool(
         name="ogc_collections",
         description="""Discovery tool: retrieve the list of all available OGC feature collections (spatial datasets) with metadata.
 Use this tool when you need to discover available datasets (collectionIds) before calling
-ogc_collection, ogc_collection_schema, ogc_collection_queryables, ogc_collection_items, or ogc_feature_by_id.
-Do NOT use this to fetch actual features — use ogc_collection_items or ogc_feature_by_id once you have the collectionId.
+ogc_collection, ogc_collection_schema, ogc_collection_queryables, or ogc_collection_items.
+Do NOT use this to fetch actual features — use ogc_collection_items once you have the collectionId.
 
 Returns: List of feature collection metadata objects with id, title, description, item type, and navigation links.
 
@@ -96,7 +49,7 @@ Example Request: https://api.cloud.precisely.com/v1/ogcapi/enrich/collections"""
         description="""Retrieve metadata for a specific OGC feature collection identified by collectionId.
 Returns title, description, item type, and links to items and schema for the collection.
 Use ogc_collections first if you do not yet know the collectionId.
-Do NOT use this to fetch actual features — use ogc_collection_items or ogc_feature_by_id instead.
+Do NOT use this to fetch actual features — use ogc_collection_items instead.
 Do NOT use this for column/field schema — use ogc_collection_schema or ogc_collection_queryables instead.
 
 Returns: Collection metadata object with id, title, description, and navigation links.
@@ -153,7 +106,9 @@ Example Request: https://api.cloud.precisely.com/v1/ogcapi/enrich/collections/pr
         name="ogc_collection_items",
         description="""Fetch features of the feature collection with id `{collectionId}` subject to parameters. Use ogc_collections tool to list all available collections and their ids, ogc_collection_queryables tool to get properties that can be used for filtering, and get_spatial_products tool to discover layer extents for bbox, data vintage, recommended label columns, and other metadata.
 
-Additional capabilities include:
+When a featureId is provided, retrieves a single feature having that unique id from the collection.
+
+When no featureId is provided, additional capabilities include:
 - **Filtering:** Supports attribute-based filtering using CQL (Common Query Language).
 - **Pagination:** Use `limit` and `offset` parameters to paginate results.
 - **Spatial Queries:**
@@ -176,41 +131,30 @@ Example 6 Request (Items with filter and s_within): https://api.cloud.precisely.
 
 Example 7 Request (Items with filter and s_intersects): https://api.cloud.precisely.com/v1/ogcapi/enrich/collections/properties/buildings/items?filter=s_intersects(GEOM,POLYGON ((-74.009523 40.703347, -74.010445 40.704257, -74.011078 40.704062, -74.011127 40.703363, -74.010526 40.702822, -74.009523 40.703347)))&limit=100
 
-Example 8 Request (Items with filter and = operator): https://api.cloud.precisely.com/v1/ogcapi/enrich/collections/properties/buildings/items?filter=bldgid%3D'B000CTPA4MY1'""",
+Example 8 Request (Items with filter and = operator): https://api.cloud.precisely.com/v1/ogcapi/enrich/collections/properties/buildings/items?filter=bldgid%3D'B000CTPA4MY1'
+
+Example 9 Request (Single feature by ID): https://api.cloud.precisely.com/v1/ogcapi/enrich/collections/properties/buildings/items/1""",
         inputSchema={
             "type": "object",
             "properties": {
                 "collectionId": {"type": "string", "description": "The unique identifier for the feature collection (e.g., 'properties/buildings')"},
-                "limit": {"type": "string", "description": "Number of features to return. Default: 10."},
-                "offset": {"type": "string", "description": "Number of features to skip. Default: 0."},
-                "bbox": {"type": "string", "description": "Bounding box for spatial filtering (minX, minY, maxX, maxY) (e.g., '-74.2,40.8,-73.9,40.9')"},
-                "filter": {"type": "string", "description": "Filter query in CQL format. (e.g., type = 'residential'"}
+                "featureId": {"type": "string", "description": "The unique identifier for a specific feature within the collection. When provided, returns a single feature (e.g., '1')"},
+                "limit": {"type": "string", "description": "Number of features to return. Default: 10. Ignored when featureId is provided."},
+                "offset": {"type": "string", "description": "Number of features to skip. Default: 0. Ignored when featureId is provided."},
+                "bbox": {"type": "string", "description": "Bounding box for spatial filtering (minX, minY, maxX, maxY) (e.g., '-74.2,40.8,-73.9,40.9'). Ignored when featureId is provided."},
+                "filter": {"type": "string", "description": "Filter query in CQL format. (e.g., type = 'residential'). Ignored when featureId is provided."}
             },
             "required": ["collectionId"]
         }
     ),
-    Tool(
-        name="ogc_feature_by_id",
-        description="""Retrieves a single feature having unique id `{featureId}` from collection with id `{collectionId}`.
-
-Returns: GeoJSON FeatureCollection with geometry and properties of the feature(s).
-
-Example Request: https://api.cloud.precisely.com/v1/ogcapi/enrich/collections/properties/buildings/items/1""",
-        inputSchema={
-            "type": "object",
-            "properties": {
-                "collectionId": {"type": "string", "description": "The unique identifier for the feature collection (e.g., 'properties/buildings')"},
-                "featureId": {"type": "string", "description": "The unique identifier for the feature within the collection (e.g., '1')"}
-            },
-            "required": ["collectionId", "featureId"]
-        }
-    ),
     # ========================================
-    # WMS (Web Map Service) APIs (2 tools)
+    # WMS (Web Map Service) APIs (1 tool)
     # ========================================
     Tool(
-        name="wms_get_request",
-        description="""Processes following WMS requests using HTTP GET: GetCapabilities, GetMap, or GetFeatureInfo. Use GetCapabilities to retrieve all available layers, their styles, CRS, and geographic bounding box. Use get_spatial_products tool to discover recommended styles, summary attributes, label columns, and data vintage, layer extents, and other metadata.
+        name="wms_request",
+        description="""Processes WMS requests using HTTP GET or HTTP POST. Supports GetCapabilities, GetMap, and GetFeatureInfo via GET. Supports GetMap with custom SLD styling via POST (automatically triggered when SLD_BODY is provided). Use GetCapabilities to retrieve all available layers, their styles, CRS, and geographic bounding box. Use get_spatial_products tool to discover recommended styles, summary attributes, label columns, and data vintage, layer extents, and other metadata.
+
+When the STYLES parameter is left empty, the styling defined in SLD_BODY (if provided) is applied. If the STYLES parameter specifies a server-side style, the SLD_BODY is ignored, even if it is included in the request.
 
 Returns: For GetMap success: Dict with 'image_base64' (str), 'content_type' (str), 'size_bytes' (int). For GetCapabilities success: Dict with 'xml' (str), 'content_type' (str). For GetFeatureInfo success: JSON dict. On any error (auth, invalid params, or WMS ServiceException): Dict with 'error' (str) containing the error or ServiceExceptionReport XML.
 
@@ -227,7 +171,19 @@ Example 4 GetMap Request (WMS version 1.3.0, CRS parameter for EPSG:4326, Axis o
 https://api.cloud.precisely.com/v1/Spatial/WMS?VERSION=1.3.0&SERVICE=WMS&REQUEST=GetMap&CRS=EPSG:4326&BBOX=24,-125,50,-66&WIDTH=400&HEIGHT=300&Layers=census_state&STYLES=census_state&FORMAT=image/png
 
 Example 5 GetFeatureInfo Request:
-https://api.cloud.precisely.com/v1/spatial/wms?VERSION=1.3.0&SERVICE=WMS&REQUEST=GetFeatureInfo&CRS=EPSG:4326&BBOX=29.19367847889249035,-98.56156199862394374,29.35037762857998089,-98.33146912069426548&WIDTH=400&HEIGHT=300&LAYERS=wildfire_risk&INFO_FORMAT=application/json&QUERY_LAYERS=wildfire_risk&I=1&J=1&PIXELSEARCHRADIUS=10""",
+https://api.cloud.precisely.com/v1/spatial/wms?VERSION=1.3.0&SERVICE=WMS&REQUEST=GetFeatureInfo&CRS=EPSG:4326&BBOX=29.19367847889249035,-98.56156199862394374,29.35037762857998089,-98.33146912069426548&WIDTH=400&HEIGHT=300&LAYERS=wildfire_risk&INFO_FORMAT=application/json&QUERY_LAYERS=wildfire_risk&I=1&J=1&PIXELSEARCHRADIUS=10
+
+Example 6 POST GetMap Request for one layer (solid brown fill with darker brown outline for buildings):
+POST https://api.cloud.precisely.com/v1/spatial/wms?SERVICE=WMS&VERSION=1.3.0&REQUEST=GetMap&BBOX=37.78662956646336823%2C-122.2745967175037549%2C37.81410536165775227%2C-122.2403683391127061&CRS=EPSG%3A4326&WIDTH=1062&HEIGHT=853&LAYERS=buildings&STYLES=&FORMAT=image%2Fpng&TRANSPARENT=TRUE
+Content-Type: application/x-www-form-urlencoded
+BODY: SLD_BODY={"styleDetails": [{"themeList": {"theme": [{"type": "OverrideTheme","style": {"type": "MapBasicCompositeStyle","AreaStyle": {"type": "MapBasicAreaStyle","MapBasicPen": {"width": 1,"pattern": 2,"color": "#964B00","unit": "PIXEL"},"MapBasicBrush": {"pattern": 2,"foregroundColor": "#E0AB8B","backgroundColor": "#C0C0C0"}}}}]}}]}
+(SLD_BODY must be URL-encoded when sent as form data)
+
+Example 7 POST GetMap Request for two layers (solid brown fill for buildings, blue star icon for address_fabric points). Note: styleDetails is an array with one entry per layer, each entry containing the layer name and its themeList:
+POST https://api.cloud.precisely.com/v1/spatial/wms?SERVICE=WMS&VERSION=1.3.0&REQUEST=GetMap&BBOX=37.78662956646336823%2C-122.2745967175037549%2C37.81410536165775227%2C-122.2403683391127061&CRS=EPSG%3A4326&WIDTH=1062&HEIGHT=853&LAYERS=buildings,address_fabric&STYLES=&FORMAT=image%2Fpng&TRANSPARENT=TRUE
+Content-Type: application/x-www-form-urlencoded
+BODY: SLD_BODY={"styleDetails": [{"layer": {"name": "address_fabric","type": "NamedLayer"},"themeList": {"theme": [{"type": "OverrideTheme","style": {"type": "MapBasicCompositeStyle","PointStyle": {"type": "MapBasicPointStyle","MapBasicSymbol": {"type": "MapBasicFontSymbol","shape": 36,"size": 12,"color": "255","fontName": "MapInfo Symbols","rotation": 0,"bold": false,"dropShadow": false,"border": "NONE"}}}}]}},{"layer": {"name": "buildings","type": "NamedLayer"},"themeList": {"theme": [{"type": "OverrideTheme","style": {"type": "MapBasicCompositeStyle","AreaStyle": {"type": "MapBasicAreaStyle","MapBasicPen": {"width": 1,"pattern": 2,"color": "#964B00","unit": "PIXEL"},"MapBasicBrush": {"pattern": 2,"foregroundColor": "#E0AB8B","backgroundColor": "#C0C0C0"}}}}]}}]}
+(SLD_BODY must be URL-encoded when sent as form data)""",
         inputSchema={
             "type": "object",
             "properties": {
@@ -255,63 +211,31 @@ https://api.cloud.precisely.com/v1/spatial/wms?VERSION=1.3.0&SERVICE=WMS&REQUEST
                 "Y": {"type": "string", "description": "Y pixel coordinate for GetFeatureInfo (WMS 1.1.1)."},
                 "Feature_Count": {"type": "string", "description": "Maximum number of features returned for GetFeatureInfo."},
                 "PIXELSEARCHRADIUS": {"type": "string", "description": "Pixel search radius for GetFeatureInfo."},
-                "BGCOLOR": {"type": "string", "description": "Hex RGB background color for the map image."},
+                "BGCOLOR": {"type": "string", "description": "Background color in hex format e.g. '0xFF0000' for red, '0x0000FF' for blue. Requires TRANSPARENT=FALSE to take effect."},
                 "RESOLUTION": {"type": "string", "description": "Resolution of the map image. Minimum 72 dpi."},
-                "EXCEPTIONS": {"type": "string", "description": "Format for exception reporting."}
+                "EXCEPTIONS": {"type": "string", "description": "Format for reporting exceptions. Supported values: 'XML' (default, returns ServiceExceptionReport XML), 'INIMAGE' (renders error message into the response image), 'BLANK' (returns a blank image on error)."},
+                "SLD_BODY": {"type": "string", "description": "Proprietary Precisely JSON style definition for customizing layer appearance. When provided, the request is automatically sent as HTTP POST with SLD_BODY as form data."},
             },
             "required": ["REQUEST", "SERVICE", "VERSION"]
         }
     ),
-    Tool(
-        name="wms_post_get_map",
-        description="""Processes WMS GetMap requests using HTTP POST. Supports both WMS 1.3.0 (use 'crs' param) and WMS 1.1.1 (use 'srs' param). Accepts SLD_BODY as a form parameter (URL-encoded JSON). Use wms_get_request GetCapabilities to retrieve all available layers, their styles, CRS/SRS, and geographic bounding box. Use get_spatial_products tool to discover recommended styles, and data vintage, layer extents, and other metadata.
-
-When the STYLES parameter is left empty, the styling defined in SLD_BODY (if provided) is applied. If the STYLES parameter specifies a server-side style, the SLD_BODY is ignored, even if it is included in the request.
-
-Returns: On success: Dict with 'image_base64' (str), 'content_type' (str), 'size_bytes' (int). On any error (auth, invalid params, or WMS ServiceException): Dict with 'error' (str) containing the error or ServiceExceptionReport XML.
-
-Example 1 Post Request for one layer (solid brown fill with darker brown outline for buildings):
-POST https://api.cloud.precisely.com/v1/spatial/wms?SERVICE=WMS&VERSION=1.3.0&REQUEST=GetMap&BBOX=37.78662956646336823%2C-122.2745967175037549%2C37.81410536165775227%2C-122.2403683391127061&CRS=EPSG%3A4326&WIDTH=1062&HEIGHT=853&LAYERS=buildings&STYLES=&FORMAT=image%2Fpng&TRANSPARENT=TRUE
-Content-Type: application/x-www-form-urlencoded
-BODY: SLD_BODY={"styleDetails": [{"themeList": {"theme": [{"type": "OverrideTheme","style": {"type": "MapBasicCompositeStyle","AreaStyle": {"type": "MapBasicAreaStyle","MapBasicPen": {"width": 1,"pattern": 2,"color": "#964B00","unit": "PIXEL"},"MapBasicBrush": {"pattern": 2,"foregroundColor": "#E0AB8B","backgroundColor": "#C0C0C0"}}}}]}}]}
-(SLD_BODY must be URL-encoded when sent as form data)
-
-Example 2 Post Request for two layers (solid brown fill for buildings, blue star icon for address_fabric points). Note: styleDetails is an array with one entry per layer, each entry containing the layer name and its themeList:
-POST https://api.cloud.precisely.com/v1/spatial/wms?SERVICE=WMS&VERSION=1.3.0&REQUEST=GetMap&BBOX=37.78662956646336823%2C-122.2745967175037549%2C37.81410536165775227%2C-122.2403683391127061&CRS=EPSG%3A4326&WIDTH=1062&HEIGHT=853&LAYERS=buildings,address_fabric&STYLES=&FORMAT=image%2Fpng&TRANSPARENT=TRUE
-Content-Type: application/x-www-form-urlencoded
-BODY: SLD_BODY={"styleDetails": [{"layer": {"name": "address_fabric","type": "NamedLayer"},"themeList": {"theme": [{"type": "OverrideTheme","style": {"type": "MapBasicCompositeStyle","PointStyle": {"type": "MapBasicPointStyle","MapBasicSymbol": {"type": "MapBasicFontSymbol","shape": 36,"size": 12,"color": "255","fontName": "MapInfo Symbols","rotation": 0,"bold": false,"dropShadow": false,"border": "NONE"}}}}]}},{"layer": {"name": "buildings","type": "NamedLayer"},"themeList": {"theme": [{"type": "OverrideTheme","style": {"type": "MapBasicCompositeStyle","AreaStyle": {"type": "MapBasicAreaStyle","MapBasicPen": {"width": 1,"pattern": 2,"color": "#964B00","unit": "PIXEL"},"MapBasicBrush": {"pattern": 2,"foregroundColor": "#E0AB8B","backgroundColor": "#C0C0C0"}}}}]}}]}
-(SLD_BODY must be URL-encoded when sent as form data)""",
-        inputSchema={
-            "type": "object",
-            "properties": {
-                "REQUEST": {"type": "string", "description": "The WMS request type. Always 'GetMap' for this endpoint."},
-                "SERVICE": {"type": "string", "description": "Service type. Always 'WMS'."},
-                "VERSION": {"type": "string", "description": "WMS version ('1.3.0' uses crs param; '1.1.1' uses srs param)."},
-                "crs": {"type": "string", "description": "Coordinate reference system for WMS 1.3.0 (e.g., 'EPSG:4326', 'CRS:84', 'EPSG:3857')."},
-                "srs": {"type": "string", "description": "Spatial reference system for WMS 1.1.1 (e.g., 'EPSG:4326', 'EPSG:3857')."},
-                "BBOX": {"type": "string", "description": "Bounding box coordinates."},
-                "width": {"type": "string", "description": "Width of the map image in pixels."},
-                "height": {"type": "string", "description": "Height of the map image in pixels."},
-                "layers": {"type": "string", "description": "Comma-separated list of layer names."},
-                "STYLES": {"type": "string", "description": "Comma-separated list of style names, one per requested layer."},
-                "FORMAT": {"type": "string", "description": "Output format (e.g., 'image/png')."},
-                "TRANSPARENT": {"type": "string", "description": "Whether the map background is transparent ('TRUE' or 'FALSE')."},
-                "SLD_BODY": {"type": "string", "description": "Proprietary Precisely JSON style definition for customizing layer appearance."},
-            },
-            "required": ["REQUEST", "SERVICE", "VERSION", "BBOX", "width", "height", "layers", "STYLES", "FORMAT"]
-        }
-    ),
     # ========================================
-    # WMTS (Web Map Tile Service) APIs (3 tools)
+    # WMTS (Web Map Tile Service) APIs (1 tool)
     # ========================================
     Tool(
         name="wmts_request",
-        description="""Handles WMTS operations via the KVP (Key-Value Pair) query parameter interface. Use Request=GetCapabilities to retrieve all available layers, their styles, tile matrix sets, and supported formats. Use Request=GetTile to retrieve a map tile image by specifying Layer, Style, TileMatrixSet, TileMatrix, TileRow, TileCol, and Format. Use get_spatial_products tool to discover recommended zoom levels, and data vintage, layer extents, and other metadata.
+        description="""Handles WMTS operations via the KVP (Key-Value Pair) query parameter interface. Use Request=GetCapabilities to retrieve all available layers, their styles, tile matrix sets, and supported formats. Use Request=GetTile to retrieve a map tile image by specifying Layer, Style, TileMatrixSet, TileMatrix, TileRow, TileCol, and Format. For GetTile, optionally set profile='simple' to use the RESTful simple profile endpoint (no Style or TileMatrixSet needed). Use get_spatial_products tool to discover recommended zoom levels, and data vintage, layer extents, and other metadata.
 
 Returns: For GetCapabilities: Dict with 'xml' (str) containing the capabilities XML document and 'content_type' (str). For GetTile: Dict with 'image_base64' (str), 'content_type' (str), 'size_bytes' (int).
 
 Example 1 GetCapabilities Request:
-https://api.cloud.precisely.com/v1/spatial/wmts?SERVICE=WMTS&REQUEST=GetCapabilities&ACCEPTVERSIONS={version}""",
+https://api.cloud.precisely.com/v1/spatial/wmts?SERVICE=WMTS&REQUEST=GetCapabilities&ACCEPTVERSIONS={version}
+
+Example 2 GetTile (standard KVP) Request:
+https://api.cloud.precisely.com/v1/spatial/wmts?SERVICE=WMTS&REQUEST=GetTile&VERSION=1.0.0&LAYER=wildfire_risk&STYLE=default&TILEMATRIXSET=WorldWebMercatorQuad_0_to_19&TILEMATRIX=12&TILEROW=1550&TILECOL=1190&FORMAT=image/png
+
+Example 3 GetTile (simple profile) Request:
+https://api.cloud.precisely.com/v1/spatial/wmts/1.0.0/simpleProfileTile/tiles/wildfire_risk/12/1190/1550.png""",
         inputSchema={
             "type": "object",
             "properties": {
@@ -323,56 +247,15 @@ https://api.cloud.precisely.com/v1/spatial/wmts?SERVICE=WMTS&REQUEST=GetCapabili
                 },
                 "Version": {"type": "string", "description": "WMTS version (e.g., '1.0.0').", "enum": ["1.0.0"]},
                 "Layer": {"type": "string", "description": "Layer name for GetTile request."},
-                "Style": {"type": "string", "description": "Style name for GetTile request."},
-                "TileMatrixSet": {"type": "string", "description": "Tile matrix set identifier for GetTile request."},
+                "Style": {"type": "string", "description": "Style name for GetTile request (not needed when profile='simple')."},
+                "TileMatrixSet": {"type": "string", "description": "Tile matrix set identifier for GetTile request (not needed when profile='simple')."},
                 "TileMatrix": {"type": "string", "description": "Tile matrix (zoom level) for GetTile request."},
                 "TileRow": {"type": "integer", "description": "Tile row for GetTile request."},
                 "TileCol": {"type": "integer", "description": "Tile column for GetTile request."},
-                "Format": {"type": "string", "description": "Output format for GetTile. 'image/png' or 'application/vnd.mapbox-vector-tile'"}
+                "Format": {"type": "string", "description": "Output format for GetTile. 'image/png' or 'application/vnd.mapbox-vector-tile' for KVP; 'png' or 'mvt' for simple profile."},
+                "profile": {"type": "string", "description": "RESTful tile profile. Use 'simple' for the simple profile endpoint (fewer required params: no Style or TileMatrixSet needed). Omit for the default KVP endpoint.", "enum": ["simple"]}
             },
             "required": ["Service", "Request"]
-        }
-    ),
-    Tool(
-        name="wmts_get_standard_tile",
-        description="""Returns a map tile, using standard parameters/approach. RESTful encoding of WMTS service. Use wmts_request with Request=GetCapabilities to retrieve all available layers, their styles, tile matrix sets, and supported formats. Use get_spatial_products tool to discover recommended zoom levels, and data vintage, layer extents, and other metadata.
-
-Returns: Dict with 'image_base64' (str), 'content_type' (str), 'size_bytes' (int) containing the requested map tile.
-
-Example Request: https://api.cloud.precisely.com/v1/spatial/wmts/1.0.0/default/tiles/wildfire_risk/default/WorldWebMercatorQuad_0_to_19/12/1190/1550.png""",
-        inputSchema={
-            "type": "object",
-            "properties": {
-                "Version": {"type": "string", "description": "WMTS version (e.g., '1.0.0')."},
-                "Layer": {"type": "string", "description": "Layer name (e.g., 'parcels', 'wildfire_risk')."},
-                "Style": {"type": "string", "description": "Style name. Comma-separated list of one rendering style per requested layer (e.g., 'default')."},
-                "TileMatrixSet": {"type": "string", "description": "Tile matrix set identifier (e.g., 'WorldWebMercatorQuad_0_to_19')."},
-                "TileMatrix": {"type": "string", "description": "Tile matrix (zoom level)."},
-                "TileCol": {"type": "integer", "description": "Tile column number."},
-                "TileRow": {"type": "integer", "description": "Tile row number."},
-                "Format": {"type": "string", "description": "Output format. 'png' or 'mvt'"}
-            },
-            "required": ["Version", "Layer", "Style", "TileMatrixSet", "TileMatrix", "TileCol", "TileRow", "Format"]
-        }
-    ),
-    Tool(
-        name="wmts_get_simple_tile",
-        description="""Returns a map tile, using less parameters/simple approach. Use this tool when you do NOT need to specify Style or TileMatrixSet. RESTful encoding of WMTS service. Use wmts_request with Request=GetCapabilities to retrieve all available layers, their styles, tile matrix sets, and supported formats. Use get_spatial_products tool to discover recommended zoom levels, and data vintage, layer extents, and other metadata.
-
-Returns: Dict with 'image_base64' (str), 'content_type' (str), 'size_bytes' (int) containing the requested map tile.
-
-Example Request: https://api.cloud.precisely.com/v1/spatial/wmts/1.0.0/simpleProfileTile/tiles/wildfire_risk/12/1190/1550.png""",
-        inputSchema={
-            "type": "object",
-            "properties": {
-                "Version": {"type": "string", "description": "WMTS version (e.g., '1.0.0')."},
-                "Layer": {"type": "string", "description": "Layer name (e.g., 'parcels', 'wildfire_risk')."},
-                "TileMatrix": {"type": "string", "description": "Tile matrix (zoom level)."},
-                "TileCol": {"type": "integer", "description": "Tile column number."},
-                "TileRow": {"type": "integer", "description": "Tile row number."},
-                "Format": {"type": "string", "description": "Output format. 'png' or 'mvt'"}
-            },
-            "required": ["Version", "Layer", "TileMatrix", "TileCol", "TileRow", "Format"]
         }
     ),
     ]

--- a/dis-locate-apis-v2/mcp_servers/tools/map_services.py
+++ b/dis-locate-apis-v2/mcp_servers/tools/map_services.py
@@ -19,7 +19,7 @@ def get_tools() -> list[Tool]:
 Use this to discover what spatial functions (e.g., s_contains, s_within, s_intersects) can be used
 in filter expressions for ogc_collection_items queries.
 
-Returns: List of spatial functions with their names, argument types, and return types.
+Output: List of spatial functions with their names, argument types, and return types.
 
 Example Request: https://api.cloud.precisely.com/v1/ogcapi/enrich/functions""",
         inputSchema={
@@ -35,7 +35,7 @@ Use this tool when you need to discover available datasets (collectionIds) befor
 ogc_collection, ogc_collection_schema, ogc_collection_queryables, or ogc_collection_items.
 Do NOT use this to fetch actual features — use ogc_collection_items once you have the collectionId.
 
-Returns: List of feature collection metadata objects with id, title, description, item type, and navigation links.
+Output: List of feature collection metadata objects with id, title, description, item type, and navigation links.
 
 Example Request: https://api.cloud.precisely.com/v1/ogcapi/enrich/collections""",
         inputSchema={
@@ -52,7 +52,7 @@ Use ogc_collections first if you do not yet know the collectionId.
 Do NOT use this to fetch actual features — use ogc_collection_items instead.
 Do NOT use this for column/field schema — use ogc_collection_schema or ogc_collection_queryables instead.
 
-Returns: Collection metadata object with id, title, description, and navigation links.
+Output: Collection metadata object with id, title, description, and navigation links.
 
 Example Request: https://api.cloud.precisely.com/v1/ogcapi/enrich/collections/properties/buildings""",
         inputSchema={
@@ -71,7 +71,7 @@ Call ogc_collections first if you do not yet know the collectionId.
 Do NOT use this for filtering — for filterable/queryable fields only, use ogc_collection_queryables instead
 (ogc_collection_queryables is a subset of ogc_collection_schema focused on fields usable in CQL filter expressions).
 
-Returns: JSON schema with all field names, data types (string, integer, double, etc.), and descriptions.
+Output: JSON schema with all field names, data types (string, integer, double, etc.), and descriptions.
 
 Example Request: https://api.cloud.precisely.com/v1/ogcapi/enrich/collections/properties/buildings/schema""",
         inputSchema={
@@ -91,7 +91,7 @@ Use this tool before constructing filter queries for ogc_collection_items to ver
 Call ogc_collections first if you do not yet know the collectionId.
 Do NOT use this if you need all fields including non-queryable ones — use ogc_collection_schema instead.
 
-Returns: List of queryable property definitions with field name, data type/format, and description.
+Output: List of queryable property definitions with field name, data type/format, and description.
 
 Example Request: https://api.cloud.precisely.com/v1/ogcapi/enrich/collections/properties/buildings/queryables""",
         inputSchema={
@@ -115,7 +115,7 @@ When no featureId is provided, additional capabilities include:
   - **Bounding Box (bbox):** Retrieve features within a rectangular spatial extent (`minX, minY, maxX, maxY`).
   - **Spatial Filters:** Support for `contains`, `intersects`, and `within` (OGC Filter Encoding).
 
-Returns: GeoJSON FeatureCollection with features matching the query, and pagination links.
+Output: GeoJSON FeatureCollection with features matching the query, and pagination links.
 
 Example 1 Request (Items without additional parameters): https://api.cloud.precisely.com/v1/ogcapi/enrich/collections/properties/buildings/items
 
@@ -156,19 +156,19 @@ Example 9 Request (Single feature by ID): https://api.cloud.precisely.com/v1/ogc
 
 When the STYLES parameter is left empty, the styling defined in SLD_BODY (if provided) is applied. If the STYLES parameter specifies a server-side style, the SLD_BODY is ignored, even if it is included in the request.
 
-Returns: For GetMap success: Dict with 'image_base64' (str), 'content_type' (str), 'size_bytes' (int). For GetCapabilities success: Dict with 'xml' (str), 'content_type' (str). For GetFeatureInfo success: JSON dict. On any error (auth, invalid params, or WMS ServiceException): Dict with 'error' (str) containing the error or ServiceExceptionReport XML.
+Output: For GetMap success: Dict with 'image_base64' (str), 'content_type' (str), 'size_bytes' (int). For GetCapabilities success: Dict with 'xml' (str), 'content_type' (str). For GetFeatureInfo success: JSON dict. On any error (auth, invalid params, or WMS ServiceException): Dict with 'error' (str) containing the error or ServiceExceptionReport XML.
 
 Example 1 GetCapabilities Request:
 https://api.cloud.precisely.com/v1/Spatial/WMS?VERSION=1.3.0&SERVICE=WMS&REQUEST=GetCapabilities
 
 Example 2 GetMap Request (WMS version 1.1.1, SRS parameter for EPSG:4326, Axis order lon-lat for BBOX):
-https://api.cloud.precisely.com/v1/Spatial/WMS?VERSION=1.1.1&SERVICE=WMS&REQUEST=GetMap&SRS=EPSG:4326&BBOX=-125,24,-66,50&WIDTH=400&HEIGHT=300&Layers=census_state&STYLES=census_state&FORMAT=image/png
+https://api.cloud.precisely.com/v1/Spatial/WMS?VERSION=1.1.1&SERVICE=WMS&REQUEST=GetMap&SRS=EPSG:4326&BBOX=-125,24,-66,50&WIDTH=400&HEIGHT=300&Layers=flood_risk&STYLES=flood_risk&FORMAT=image/png
 
 Example 3 GetMap Request (WMS version 1.3.0, CRS parameter for CRS:84, Axis order lon-lat for BBOX):
-https://api.cloud.precisely.com/v1/Spatial/WMS?VERSION=1.3.0&SERVICE=WMS&REQUEST=GetMap&CRS=CRS:84&BBOX=-125,24,-66,50&WIDTH=400&HEIGHT=300&Layers=census_state&STYLES=census_state&FORMAT=image/png
+https://api.cloud.precisely.com/v1/Spatial/WMS?VERSION=1.3.0&SERVICE=WMS&REQUEST=GetMap&CRS=CRS:84&BBOX=-125,24,-66,50&WIDTH=400&HEIGHT=300&Layers=flood_risk&STYLES=flood_risk&FORMAT=image/png
 
 Example 4 GetMap Request (WMS version 1.3.0, CRS parameter for EPSG:4326, Axis order lat-lon for BBOX):
-https://api.cloud.precisely.com/v1/Spatial/WMS?VERSION=1.3.0&SERVICE=WMS&REQUEST=GetMap&CRS=EPSG:4326&BBOX=24,-125,50,-66&WIDTH=400&HEIGHT=300&Layers=census_state&STYLES=census_state&FORMAT=image/png
+https://api.cloud.precisely.com/v1/Spatial/WMS?VERSION=1.3.0&SERVICE=WMS&REQUEST=GetMap&CRS=EPSG:4326&BBOX=24,-125,50,-66&WIDTH=400&HEIGHT=300&Layers=flood_risk&STYLES=flood_risk&FORMAT=image/png
 
 Example 5 GetFeatureInfo Request:
 https://api.cloud.precisely.com/v1/spatial/wms?VERSION=1.3.0&SERVICE=WMS&REQUEST=GetFeatureInfo&CRS=EPSG:4326&BBOX=29.19367847889249035,-98.56156199862394374,29.35037762857998089,-98.33146912069426548&WIDTH=400&HEIGHT=300&LAYERS=wildfire_risk&INFO_FORMAT=application/json&QUERY_LAYERS=wildfire_risk&I=1&J=1&PIXELSEARCHRADIUS=10
@@ -226,7 +226,7 @@ BODY: SLD_BODY={"styleDetails": [{"layer": {"name": "address_fabric","type": "Na
         name="wmts_request",
         description="""Handles WMTS operations via the KVP (Key-Value Pair) query parameter interface. Use Request=GetCapabilities to retrieve all available layers, their styles, tile matrix sets, and supported formats. Use Request=GetTile to retrieve a map tile image by specifying Layer, Style, TileMatrixSet, TileMatrix, TileRow, TileCol, and Format. For GetTile, optionally set profile='simple' to use the RESTful simple profile endpoint (no Style or TileMatrixSet needed). Use get_spatial_products tool to discover recommended zoom levels, and data vintage, layer extents, and other metadata.
 
-Returns: For GetCapabilities: Dict with 'xml' (str) containing the capabilities XML document and 'content_type' (str). For GetTile: Dict with 'image_base64' (str), 'content_type' (str), 'size_bytes' (int).
+Output: For GetCapabilities: Dict with 'xml' (str) containing the capabilities XML document and 'content_type' (str). For GetTile: Dict with 'image_base64' (str), 'content_type' (str), 'size_bytes' (int).
 
 Example 1 GetCapabilities Request:
 https://api.cloud.precisely.com/v1/spatial/wmts?SERVICE=WMTS&REQUEST=GetCapabilities&ACCEPTVERSIONS={version}

--- a/dis-locate-apis-v2/mcp_servers/tools/output_schemas.py
+++ b/dis-locate-apis-v2/mcp_servers/tools/output_schemas.py
@@ -1,5 +1,5 @@
 """
-Output schemas for all 68 MCP tools.
+Output schemas for all 51 MCP tools.
 Each schema describes the JSON structure returned by the tool on success.
 Used as `outputSchema` on Tool definitions per MCP spec 2025-11-25.
 """
@@ -43,8 +43,8 @@ GEOCODE_RESPONSE = {
     "required": ["responses"]
 }
 
-# autocomplete, autocomplete_postal_city
-AUTOCOMPLETE_RESPONSE = {
+# autocomplete_address (consolidated: street, postal/city, and express modes)
+AUTOCOMPLETE_ADDRESS_RESPONSE = {
     "type": "object",
     "properties": {
         "response": {
@@ -60,34 +60,6 @@ AUTOCOMPLETE_RESPONSE = {
                             "prediction": {"type": "string", "description": "Full predicted address string."},
                             "address": {"type": "object", "description": "Parsed address components."},
                             "addressLines": {"type": "array", "items": {"type": "string"}, "description": "Formatted address lines."},
-                            "location": {"type": "object", "description": "Geographic coordinates."}
-                        }
-                    }
-                }
-            },
-            "required": ["status"]
-        }
-    },
-    "required": ["response"]
-}
-
-# autocomplete_v2
-AUTOCOMPLETE_V2_RESPONSE = {
-    "type": "object",
-    "properties": {
-        "response": {
-            "type": "object",
-            "properties": {
-                "status": {"type": "string", "description": "Result status."},
-                "predictions": {
-                    "type": "array",
-                    "description": "List of autocomplete prediction results with explanation.",
-                    "items": {
-                        "type": "object",
-                        "properties": {
-                            "prediction": {"type": "string", "description": "Full predicted address string."},
-                            "address": {"type": "object", "description": "Parsed address components."},
-                            "addressLines": {"type": "array", "items": {"type": "string"}},
                             "location": {"type": "object", "description": "Geographic coordinates."},
                             "explanation": {"type": "object", "description": "Match explanation including source."}
                         }
@@ -119,8 +91,8 @@ LOOKUP_RESPONSE = {
     "required": ["response"]
 }
 
-# parse_address, parse_address_batch
-PARSE_ADDRESS_RESPONSE = {
+# parse_addresses (consolidated: single + batch)
+PARSE_ADDRESSES_RESPONSE = {
     "type": "object",
     "properties": {
         "responses": {
@@ -129,15 +101,20 @@ PARSE_ADDRESS_RESPONSE = {
             "items": {
                 "type": "object",
                 "properties": {
-                    "addressId": {"type": "string"},
+                    "id": {"type": "string", "description": "Client-supplied correlation id (when provided)."},
                     "status": {"type": "string"},
-                    "addressLine1": {"type": "string"},
-                    "addressLine2": {"type": "string"},
-                    "city": {"type": "string"},
-                    "stateProvince": {"type": "string"},
-                    "postalCode": {"type": "string"},
-                    "country": {"type": "string"},
-                    "firmName": {"type": "string"}
+                    "address": {
+                        "type": "object",
+                        "description": "Parsed address components.",
+                        "properties": {
+                            "addressNumber": {"type": "string"},
+                            "street": {"type": "string"},
+                            "admin1": {"type": "string"},
+                            "city": {"type": "string"},
+                            "postalCode": {"type": "string"},
+                            "unit": {"type": "string"}
+                        }
+                    }
                 },
                 "required": ["status"]
             }
@@ -195,35 +172,8 @@ GEO_LOCATE_WIFI_RESPONSE = {
 # Verification (5 tools)
 # ============================================================
 
-# verify_email
-VERIFY_EMAIL_RESPONSE = {
-    "type": "object",
-    "properties": {
-        "response": {
-            "type": "object",
-            "properties": {
-                "status": {"type": "string"},
-                "email": {
-                    "type": "object",
-                    "description": "Email verification result.",
-                    "properties": {
-                        "address": {"type": "string", "description": "The email address verified."},
-                        "result": {"type": "string", "description": "Verification result (e.g., 'valid', 'invalid')."},
-                        "subResult": {"type": "string", "description": "Detailed sub-result (e.g., 'failed_syntax_check')."},
-                        "freeEmail": {"type": "string"},
-                        "mxFound": {"type": "string"},
-                        "processedAt": {"type": "string"}
-                    }
-                }
-            },
-            "required": ["status"]
-        }
-    },
-    "required": ["response"]
-}
-
-# verify_batch_emails
-VERIFY_BATCH_EMAILS_RESPONSE = {
+# verify_emails (consolidated: single + batch)
+VERIFY_EMAILS_RESPONSE = {
     "type": "object",
     "properties": {
         "responses": {
@@ -233,8 +183,19 @@ VERIFY_BATCH_EMAILS_RESPONSE = {
                 "type": "object",
                 "properties": {
                     "status": {"type": "string"},
-                    "id": {"type": "string"},
-                    "email": {"type": "object", "description": "Email verification result."}
+                    "id": {"type": "string", "description": "Client-supplied correlation id (when provided)."},
+                    "email": {
+                        "type": "object",
+                        "description": "Email verification result.",
+                        "properties": {
+                            "address": {"type": "string", "description": "The email address verified."},
+                            "result": {"type": "string", "description": "Verification result (e.g., 'valid', 'invalid')."},
+                            "subResult": {"type": "string", "description": "Detailed sub-result (e.g., 'failed_syntax_check')."},
+                            "freeEmail": {"type": "string"},
+                            "mxFound": {"type": "string"},
+                            "processedAt": {"type": "string"}
+                        }
+                    }
                 },
                 "required": ["status"]
             }
@@ -264,35 +225,8 @@ PARSE_NAME_RESPONSE = {
     "required": ["response"]
 }
 
-# validate_phone
-VALIDATE_PHONE_RESPONSE = {
-    "type": "object",
-    "properties": {
-        "response": {
-            "type": "object",
-            "properties": {
-                "status": {"type": "string"},
-                "phoneNumber": {
-                    "type": "object",
-                    "description": "Phone validation result.",
-                    "properties": {
-                        "formattedPhoneNumber": {"type": "string"},
-                        "validStatus": {"type": "boolean"},
-                        "validationDescription": {"type": "string"},
-                        "numberType": {"type": "string"},
-                        "countryCode": {"type": "string"},
-                        "carrier": {"type": "string"}
-                    }
-                }
-            },
-            "required": ["status"]
-        }
-    },
-    "required": ["response"]
-}
-
-# validate_batch_phones
-VALIDATE_BATCH_PHONES_RESPONSE = {
+# validate_phones (consolidated: single + batch)
+VALIDATE_PHONES_RESPONSE = {
     "type": "object",
     "properties": {
         "responses": {
@@ -302,8 +236,18 @@ VALIDATE_BATCH_PHONES_RESPONSE = {
                 "type": "object",
                 "properties": {
                     "status": {"type": "string"},
-                    "id": {"type": "string"},
-                    "phoneNumber": {"type": "object", "description": "Phone validation result."}
+                    "id": {"type": "string", "description": "Client-supplied correlation id (when provided)."},
+                    "phoneNumber": {
+                        "type": "object",
+                        "description": "Phone validation result.",
+                        "properties": {
+                            "formattedPhoneNumber": {"type": "string"},
+                            "validStatus": {"type": "boolean"},
+                            "country": {"type": "string"},
+                            "phoneType": {"type": "string"},
+                            "carrierName": {"type": "string"}
+                        }
+                    }
                 },
                 "required": ["status"]
             }
@@ -313,7 +257,7 @@ VALIDATE_BATCH_PHONES_RESPONSE = {
 }
 
 # ============================================================
-# Timezone (2 tools)
+# Timezone (1 tool)
 # ============================================================
 
 TIMEZONE_RESPONSE = {
@@ -384,8 +328,8 @@ TAX_JURISDICTION_RESPONSE = {
     }
 }
 
-# psap_address, psap_location
-PSAP_RESPONSE = {
+# find_emergency_services (consolidated PSAP + AHJ)
+EMERGENCY_SERVICES_RESPONSE = {
     "type": "object",
     "properties": {
         "response": {
@@ -401,38 +345,25 @@ PSAP_RESPONSE = {
                         "type": {"type": "string"},
                         "agency": {"type": "string"},
                         "phone": {"type": "string"},
-                        "county": {"type": "string"},
-                        "contactPerson": {"type": "string"},
+                        "county": {"type": "object"},
+                        "contactPerson": {"type": "object"},
                         "siteDetails": {"type": "object"},
                         "mailingAddress": {"type": "object"}
                     }
-                }
-            },
-            "required": ["status"]
-        }
-    },
-    "required": ["response"]
-}
-
-# psap_ahj_address, psap_ahj_location, psap_ahj_fccid
-PSAP_AHJ_RESPONSE = {
-    "type": "object",
-    "properties": {
-        "response": {
-            "type": "object",
-            "properties": {
-                "status": {"type": "string"},
-                "psap": {"type": "object", "description": "PSAP information."},
+                },
                 "ahjs": {
                     "type": "array",
-                    "description": "Authorities Having Jurisdiction associated with this PSAP.",
+                    "description": "Authorities Having Jurisdiction associated with this PSAP. Present when include_ahj is true or fcc_id is used.",
                     "items": {
                         "type": "object",
                         "properties": {
                             "ahjType": {"type": "string"},
                             "ahjId": {"type": "string"},
-                            "name": {"type": "string"},
-                            "fipsCode": {"type": "string"}
+                            "agency": {"type": "string"},
+                            "phone": {"type": "string"},
+                            "fccId": {"type": "string"},
+                            "contactPerson": {"type": "object"},
+                            "mailingAddress": {"type": "object"}
                         }
                     }
                 }
@@ -686,40 +617,8 @@ TABLE_METADATA_RESPONSE = {
 }
 
 # ============================================================
-# OGC Features (10 tools)
+# OGC Features (6 tools)
 # ============================================================
-
-OGC_LANDING_PAGE = {
-    "type": "object",
-    "properties": {
-        "title": {"type": "string"},
-        "description": {"type": "string"},
-        "links": {
-            "type": "array",
-            "items": {
-                "type": "object",
-                "properties": {
-                    "href": {"type": "string"},
-                    "rel": {"type": "string"},
-                    "type": {"type": "string"},
-                    "title": {"type": "string"}
-                }
-            }
-        }
-    }
-}
-
-OGC_API_DEFINITION = {
-    "type": "object",
-    "description": "Full OpenAPI 3.0.1 specification.",
-    "properties": {
-        "openapi": {"type": "string"},
-        "info": {"type": "object"},
-        "servers": {"type": "array"},
-        "paths": {"type": "object"},
-        "components": {"type": "object"}
-    }
-}
 
 OGC_FUNCTIONS = {
     "type": "object",
@@ -737,18 +636,6 @@ OGC_FUNCTIONS = {
             }
         }
     }
-}
-
-OGC_CONFORMANCE = {
-    "type": "object",
-    "properties": {
-        "conformsTo": {
-            "type": "array",
-            "description": "List of OGC conformance class URIs.",
-            "items": {"type": "string"}
-        }
-    },
-    "required": ["conformsTo"]
 }
 
 OGC_COLLECTIONS = {
@@ -810,7 +697,7 @@ OGC_COLLECTION_QUERYABLES = {
     }
 }
 
-# ogc_collection_items, ogc_feature_by_id
+# ogc_collection_items
 OGC_FEATURE_COLLECTION = {
     "type": "object",
     "properties": {
@@ -848,8 +735,8 @@ _IMAGE_RESULT = {
     "required": ["image_base64", "content_type", "size_bytes"]
 }
 
-# wms_get_request — multi-response: GetMap→image, GetCapabilities→xml, GetFeatureInfo→json/xml
-WMS_GET_REQUEST = {
+# wms_request — multi-response: GetMap→image, GetCapabilities→xml, GetFeatureInfo→json/xml
+WMS_REQUEST = {
     "type": "object",
     "description": "Response varies by REQUEST type: GetMap returns image, GetCapabilities returns XML, GetFeatureInfo returns JSON or XML.",
     "properties": {
@@ -862,11 +749,8 @@ WMS_GET_REQUEST = {
     }
 }
 
-# wms_post_get_map — always returns image
-WMS_POST_GET_MAP = _IMAGE_RESULT
-
 # ============================================================
-# WMTS (3 tools)
+# WMTS (1 tool)
 # ============================================================
 
 # wmts_request — multi-response: GetTile→image, GetCapabilities→xml
@@ -881,43 +765,30 @@ WMTS_REQUEST = {
     }
 }
 
-# wmts_get_standard_tile, wmts_get_simple_tile — always return image
-WMTS_TILE = _IMAGE_RESULT
-
 
 # ============================================================
-# Tool name → outputSchema mapping (all 68 tools)
+# Tool name → outputSchema mapping (all 51 tools)
 # ============================================================
 TOOL_OUTPUT_SCHEMAS = {
-    # Geocoding & Address (9)
+    # Geocoding & Address (6)
     "geocode": GEOCODE_RESPONSE,
     "reverse_geocode": GEOCODE_RESPONSE,
     "verify_address": GEOCODE_RESPONSE,
-    "autocomplete": AUTOCOMPLETE_RESPONSE,
-    "autocomplete_postal_city": AUTOCOMPLETE_RESPONSE,
-    "autocomplete_v2": AUTOCOMPLETE_V2_RESPONSE,
+    "autocomplete_address": AUTOCOMPLETE_ADDRESS_RESPONSE,
     "lookup": LOOKUP_RESPONSE,
-    "parse_address": PARSE_ADDRESS_RESPONSE,
-    "parse_address_batch": PARSE_ADDRESS_RESPONSE,
+    "parse_addresses": PARSE_ADDRESSES_RESPONSE,
     # Geolocation (2)
     "geo_locate_ip_address": GEO_LOCATE_IP_RESPONSE,
     "geo_locate_wifi_access_point": GEO_LOCATE_WIFI_RESPONSE,
-    # Verification (5)
-    "verify_email": VERIFY_EMAIL_RESPONSE,
-    "verify_batch_emails": VERIFY_BATCH_EMAILS_RESPONSE,
+    # Verification (3)
+    "verify_emails": VERIFY_EMAILS_RESPONSE,
     "parse_name": PARSE_NAME_RESPONSE,
-    "validate_phone": VALIDATE_PHONE_RESPONSE,
-    "validate_batch_phones": VALIDATE_BATCH_PHONES_RESPONSE,
-    # Timezone (2)
-    "timezone_addresses": TIMEZONE_RESPONSE,
-    "timezone_locations": TIMEZONE_RESPONSE,
-    # Tax & Emergency (6)
+    "validate_phones": VALIDATE_PHONES_RESPONSE,
+    # Timezone (1)
+    "get_timezones": TIMEZONE_RESPONSE,
+    # Tax & Emergency (2)
     "lookup_tax_jurisdiction": TAX_JURISDICTION_RESPONSE,
-    "psap_address": PSAP_RESPONSE,
-    "psap_location": PSAP_RESPONSE,
-    "psap_ahj_address": PSAP_AHJ_RESPONSE,
-    "psap_ahj_location": PSAP_AHJ_RESPONSE,
-    "psap_ahj_fccid": PSAP_AHJ_RESPONSE,
+    "find_emergency_services": EMERGENCY_SERVICES_RESPONSE,
     # GraphQL Property & Risk (9)
     "get_property_data": GET_PROPERTY_DATA,
     "get_property_attributes_by_address": GET_PROPERTY_ATTRIBUTES,
@@ -951,22 +822,15 @@ TOOL_OUTPUT_SCHEMAS = {
     "get_spatial_products": SPATIAL_PRODUCTS_RESPONSE,
     "list_spatial_tables": SPATIAL_TABLES_RESPONSE,
     "get_table_metadata": TABLE_METADATA_RESPONSE,
-    # OGC Features (10)
-    "ogc_landing_page": OGC_LANDING_PAGE,
-    "ogc_api_definition": OGC_API_DEFINITION,
+    # OGC Features (6)
     "ogc_functions": OGC_FUNCTIONS,
-    "ogc_conformance": OGC_CONFORMANCE,
     "ogc_collections": OGC_COLLECTIONS,
     "ogc_collection": OGC_COLLECTION,
     "ogc_collection_schema": OGC_COLLECTION_SCHEMA,
     "ogc_collection_queryables": OGC_COLLECTION_QUERYABLES,
     "ogc_collection_items": OGC_FEATURE_COLLECTION,
-    "ogc_feature_by_id": OGC_FEATURE_COLLECTION,
-    # WMS (2)
-    "wms_get_request": WMS_GET_REQUEST,
-    "wms_post_get_map": WMS_POST_GET_MAP,
-    # WMTS (3)
+    # WMS (1)
+    "wms_request": WMS_REQUEST,
+    # WMTS (1)
     "wmts_request": WMTS_REQUEST,
-    "wmts_get_standard_tile": WMTS_TILE,
-    "wmts_get_simple_tile": WMTS_TILE,
 }

--- a/dis-locate-apis-v2/mcp_servers/tools/spatial_analysis.py
+++ b/dis-locate-apis-v2/mcp_servers/tools/spatial_analysis.py
@@ -13,7 +13,7 @@ def get_tools() -> list[Tool]:
         name="find_nearest_candidates",
         description="""Returns nearest locations or points of interest within specified distance from input geometry/address, by default ordered closest first. Input can also be an address, no need to geocode it. Use list_spatial_tables tool to find available spatial tables/data, get_table_metadata tool for available columns and their metadata, and get_spatial_products tool to discover recommended summary attributes, label columns, and data vintage, layer extents, and other metadata.
 
-Returns: GeoJSON FeatureCollection with features. Includes distance values, recordsMatched, recordsReturned, and metadata.
+Output: GeoJSON FeatureCollection with features. Includes distance values, recordsMatched, recordsReturned, and metadata.
 
 Example 1 Request (Geometry):
 {'tableName': '/risks/wildfire_risk_fire_perimeter', 'attributes': ['incremental_s_no', 'state', 'wr_id'], 'location': {'format': 'wkt', 'value': 'LINESTRING (-122.769499 38.005947, -122.773625 37.999047)'}, 'withinDistance': '10 mi', 'distanceAttributeName': 'dist', 'maxFeatures': '5', 'inputPointAttributeName': 'inputPoint', 'targetPointAttributeName': 'targetPoint', 'bearingAttributeName': 'bearing'}
@@ -51,7 +51,7 @@ Spatial operation semantics — choose carefully based on the query intent:
 - Use 'within' when the query asks for table features that are INSIDE the input geometry. Natural language cues: "within", "inside", "that fall within this area". Example: "find all parcels within this polygon" → parcels are within the polygon → use 'within'.
 - Use 'intersects' when the query asks for table features that INTERSECT, CROSS, TOUCH, OVERLAP or share any portion of the input geometry. Natural language cues: "intersecting", "crossing", "overlapping".
 
-Returns: GeoJSON FeatureCollection with matching features, recordsMatched, recordsReturned, and metadata.
+Output: GeoJSON FeatureCollection with matching features, recordsMatched, recordsReturned, and metadata.
 
 Example 1 Request (Geometry, WITHIN):
 {'spatialOperation': 'WITHIN', 'tableName': '/risks/flood_risk', 'attributes': ['statecode', 'type', 'mapname', 'incremental_s_no'], 'location': {'format': 'wkt', 'value': 'MULTIPOLYGON (((-122.399306 37.712211, -122.398975 37.712132, -122.399007 37.712049, -122.399338 37.712127, -122.399316 37.712185, -122.399306 37.712211)))'}, 'bufferDistance': '10 mi'}
@@ -86,7 +86,7 @@ Example 3 Request (Address, CONTAINS — find the building enclosing an address)
         name="overlap",
         description="""Returns geometries that represent the overlap of the input geometry/address with the geometries in the target table, along with the percentage and area/length of overlap/intersection. Input can also be an address, no need to geocode it. If input is an address, bufferDistance is required. Use list_spatial_tables tool to find available spatial tables/data, get_table_metadata tool for available columns and their metadata, and get_spatial_products tool to discover recommended summary attributes, label columns, and data vintage, layer extents, and other metadata.
 
-Returns: GeoJSON FeatureCollection with overlapping geometries, intersection area/length, and percentage of overlap with both target and input geometries.
+Output: GeoJSON FeatureCollection with overlapping geometries, intersection area/length, and percentage of overlap with both target and input geometries.
 
 Example 1 Request (Geometry):
 {'tableName': '/risks/historical_weather_hurricanelines_world', 'uom': 'mi', 'attributes': ['stormname', 'windspeed'], 'location': {'format': 'wkt', 'value': 'POLYGON ((-74.286804 40.515887, -74.292297 40.478292, -73.66333 40.560765, -73.737488 40.839788, -74.002533 40.909361, -74.286804 40.515887))'}, 'totalAttributeName': 'tc'}
@@ -118,7 +118,7 @@ Example 2 Request (Address):
         description="""Discovery tool: list all available Enrich Data products with metadata needed to make informed spatial queries.
 Call this before querying spatial data when you need to discover: product family, geography coverage, data vintage, recommended zoom levels, recommended styles, summary attributes, label column names, and layer extents.
 
-Returns: List of product metadata objects with productId, productName, productFamily, vintage, geography, and layers (including layerId, displayName, featureTable, recommendedStyle).
+Output: List of product metadata objects with productId, productName, productFamily, vintage, geography, and layers (including layerId, displayName, featureTable, recommendedStyle).
 
 Use this before: wms_get_request, wms_post_get_map, wmts_request, wmts_get_standard_tile, wmts_get_simple_tile, find_nearest_candidates, search_at_location, overlap, summarize.
 
@@ -135,7 +135,7 @@ Example Request: https://api.cloud.precisely.com/v1/spatial/products""",
 Call this before calling find_nearest_candidates, search_at_location, overlap, summarize, or get_table_metadata when the correct tableName is not yet known.
 Do NOT use this if you already know the tableName — call get_table_metadata directly for column/schema details.
 
-Returns: List of spatial table path strings (e.g., ['/risks/flood_risk', '/properties/buildings', ...]).
+Output: List of spatial table path strings (e.g., ['/risks/flood_risk', '/properties/buildings', ...]).
 
 Example Request: https://api.cloud.precisely.com/v1/spatial/tables""",
         inputSchema={
@@ -150,7 +150,7 @@ Example Request: https://api.cloud.precisely.com/v1/spatial/tables""",
 Call this before calling find_nearest_candidates, search_at_location, overlap, or summarize when you need to know which columns are available in a table.
 Use list_spatial_tables first if the tableName is not yet known.
 
-Returns: Object with table name, columns (name, type, description), spatial bounding box, and approximate row count.
+Output: Object with table name, columns (name, type, description), spatial bounding box, and approximate row count.
 
 Note: The tableName parameter should NOT include a leading slash (e.g., 'properties/buildings', not '/properties/buildings').
 
@@ -171,7 +171,7 @@ IMPORTANT — spatialOperation selection:
 - Use 'intersects' when you want features that TOUCH or OVERLAP the input geometry (partial overlap counts).
 - Use 'within' when you want features that are FULLY CONTAINED INSIDE the input geometry. The user's query keyword 'within' (e.g., "records within 10 miles") means spatialOperation='within'.
 
-Returns: Aggregate statistics for specified columns.
+Output: Aggregate statistics for specified columns.
 
 Example 1 Request (Geometry, Intersects):
 {'spatialOperation': 'INTERSECTS', 'tableName': '/risks/historical_weather_windgrid', 'aggregateColumns': {'w9': ['min', 'max', 'avg', 'sum']}, 'location': {'format': 'wkt', 'value': 'GEOMETRYCOLLECTION (MULTIPOLYGON (((-122.399306 37.712211, -122.398975 37.712132, -122.399007 37.712049, -122.399338 37.712127, -122.399316 37.712185, -122.399306 37.712211))), LINESTRING (-121.756899 37.653383, -121.158302 37.304645, -121.690998 37.120906))'}, 'proportionalCalculation': true}

--- a/dis-locate-apis-v2/mcp_servers/tools/tax_emergency.py
+++ b/dis-locate-apis-v2/mcp_servers/tools/tax_emergency.py
@@ -1,41 +1,9 @@
 """
 Tax & Emergency Tools Module
-Contains 9 tools for tax jurisdiction lookups and PSAP (911) services
+Contains 5 tools for tax jurisdiction lookups and emergency (911/PSAP) services
 """
 from mcp.types import Tool
 from mcp_servers.tools.base_tool import handle_tool_call  # noqa: F401
-
-_PSAP_ADDRESS_SCHEMA = {
-    "type": "object",
-    "description": "Structured US address for PSAP lookup.",
-    "properties": {
-        "addressLines": {
-            "type": "array",
-            "items": {"type": "string"},
-            "description": "Street address lines (e.g., ['860 White Plains Road']).",
-            "minItems": 1
-        },
-        "city": {"type": "string", "description": "City name (e.g., 'Trumbull')."},
-        "admin1": {"type": "string", "description": "State abbreviation (e.g., 'CT')."},
-        "postalCode": {"type": "string", "description": "ZIP code (e.g., '06611')."},
-    }
-}
-
-_PSAP_LOCATION_SCHEMA = {
-    "type": "object",
-    "description": "Geographic coordinates for PSAP lookup.",
-    "properties": {
-        "coordinates": {
-            "type": "array",
-            "items": {"type": "number"},
-            "description": "Coordinates as [longitude, latitude] (e.g., [-71.0589, 42.3601]). WGS 84 datum/EPSG:4326 coordinate system.",
-            "minItems": 2,
-            "maxItems": 2
-        }
-    },
-    "required": ["coordinates"]
-}
-
 
 def get_tools() -> list[Tool]:
     """Returns list of tax and emergency tool definitions"""
@@ -43,21 +11,18 @@ def get_tools() -> list[Tool]:
         # Tax jurisdiction tool (1 consolidated tool replacing lookup_by_address/addresses/location/locations)
         Tool(
             name="lookup_tax_jurisdiction",
-            description=(
-                "Look up US tax jurisdictions (state, county, and other codes) "
-                "for one or more addresses or geographic coordinates in a single call.\n\n"
-                "Supports four usage patterns through one consistent interface:\n"
-                "  - Single address:    input_type='address', records=[{addressLines: ['123 Main St, Boston, MA']}]\n"
-                "  - Multiple addresses: input_type='address', records=[{...}, {...}]\n"
-                "  - Single coordinate: input_type='location', records=[{longitude: -71.0589, latitude: 42.3601}]\n"
-                "  - Multiple coordinates: input_type='location', records=[{...}, {...}]\n\n"
-                "Batch and single records use the same tool — pass 1 item for single lookup, N items for batch.\n"
-                "Only works for locations within the United States.\n\n"
-                "Output: For a single record, returns one tax jurisdiction object. "
-                "For multiple records, returns an array of tax jurisdiction objects, one per input record. "
-                "Each object contains tax type codes and full names "
-                "(state, county, etc.)."
-            ),
+            description="""Look up US tax jurisdictions (state, county, and other codes) for one or more addresses or geographic coordinates in a single call.
+
+Supports four usage patterns through one consistent interface:
+  - Single address:    input_type='address', records=[{addressLines: ['123 Main St, Boston, MA']}]
+  - Multiple addresses: input_type='address', records=[{...}, {...}]
+  - Single coordinate: input_type='location', records=[{longitude: -71.0589, latitude: 42.3601}]
+  - Multiple coordinates: input_type='location', records=[{...}, {...}]
+
+Batch and single records use the same tool — pass 1 item for single lookup, N items for batch.
+Only works for locations within the United States.
+
+Output: For a single record, returns one tax jurisdiction object. For multiple records, returns an array of tax jurisdiction objects, one per input record. Each object contains tax type codes and full names (state, county, etc.).""",
             inputSchema={
                 "type": "object",
                 "properties": {
@@ -124,110 +89,91 @@ def get_tools() -> list[Tool]:
                 "required": ["input_type", "records"]
             }
         ),
-        # PSAP/Emergency services tools (5 tools)
+        # Emergency services (1 consolidated tool replacing psap_address/psap_location/psap_ahj_address/psap_ahj_location/psap_ahj_fccid)
         Tool(
-            name="psap_address",
-            description=(
-                "Retrieve the PSAP (Public Safety Answering Point / 911 dispatch center) responsible for a given US address. "
-                "Returns the PSAP name, phone number, fccId, and other information. "
-                "Use this tool when you need to identify the correct 911 call center for a street address. "
-                "Do NOT use if you also need AHJ (Authority Having Jurisdiction) data — use psap_ahj_address instead. "
-                "Do NOT use if you have coordinates rather than an address — use psap_location instead. "
-                "Only works for addresses within the United States.\n\n"
-                "Output: Object with PSAP information."
-            ),
+            name="find_emergency_services",
+            description="""Find the PSAP (Public Safety Answering Point / 911 dispatch center) and optionally the AHJ (Authority Having Jurisdiction) for a US location.
+
+Provide exactly one of:
+  - address: a structured US street address
+  - location: geographic coordinates [longitude, latitude]
+  - fcc_id: an FCC-assigned PSAP identifier (from a prior call)
+
+Set include_ahj=false to retrieve only PSAP data (lighter response). Default is true (returns both PSAP and AHJ). FCC ID lookups always include AHJ regardless of the flag.
+
+Only works for locations within the United States.
+
+Output: Object with PSAP name, phone, fccId, and (when AHJ is included) an array of AHJ records with agency name, type, phone, and other details.
+
+Example — by address (PSAP only):
+  address={"addressLines": ["860 White Plains Road"], "city": "Trumbull", "admin1": "CT", "postalCode": "06611"}, include_ahj=false
+
+Example — by address (PSAP + AHJ):
+  address={"addressLines": ["860 White Plains Road"], "city": "Trumbull", "admin1": "CT", "postalCode": "06611"}
+
+Example — by coordinates (PSAP only):
+  location={"coordinates": [-71.0589, 42.3601]}, include_ahj=false
+
+Example — by coordinates (PSAP + AHJ):
+  location={"coordinates": [-71.0589, 42.3601]}
+
+Example — by FCC ID:
+  fcc_id="1404"
+""",
             inputSchema={
                 "type": "object",
                 "properties": {
-                    "address": _PSAP_ADDRESS_SCHEMA
-                },
-                "required": ["address"]
-            }
-        ),
-        Tool(
-            name="psap_location",
-            description=(
-                "Retrieve the PSAP (Public Safety Answering Point / 911 dispatch center) responsible for a given geographic coordinate. "
-                "Returns the PSAP name, phone number, fccId, and other information. "
-                "Use this tool when you have a coordinate pair (longitude, latitude) and need to identify the 911 center. "
-                "Do NOT use if you also need AHJ (Authority Having Jurisdiction) data — use psap_ahj_location instead. "
-                "Do NOT use if you have a street address rather than coordinates — use psap_address instead. "
-                "Only works for coordinates within the United States.\n\n"
-                "Output: Object with PSAP information."
-            ),
-            inputSchema={
-                "type": "object",
-                "properties": {
-                    "location": _PSAP_LOCATION_SCHEMA
-                },
-                "required": ["location"]
-            }
-        ),
-        Tool(
-            name="psap_ahj_address",
-            description=(
-                "Retrieve combined PSAP (Public Safety Answering Point / 911 dispatch center) and "
-                "AHJ (Authority Having Jurisdiction) data for a given US address in a single call. "
-                "PSAP identifies the emergency dispatch center; AHJ identifies the regulatory and code authority for the location. "
-                "Use this tool when you need both PSAP and AHJ information for an address. "
-                "Do NOT use if you only need PSAP data — use psap_address instead (lighter response). "
-                "Do NOT use if you have coordinates rather than an address — use psap_ahj_location instead. "
-                "Do NOT use if lookup is by FCC ID — use psap_ahj_fccid instead. "
-                "Only works for addresses within the United States.\n\n"
-                "Output: Object with PSAP name, phone, fccId, AHJ names "
-                "and other details."
-            ),
-            inputSchema={
-                "type": "object",
-                "properties": {
-                    "address": _PSAP_ADDRESS_SCHEMA
-                },
-                "required": ["address"]
-            }
-        ),
-        Tool(
-            name="psap_ahj_location",
-            description=(
-                "Retrieve combined PSAP (Public Safety Answering Point / 911 dispatch center) and "
-                "AHJ (Authority Having Jurisdiction) data for a given geographic coordinate in a single call. "
-                "Use this tool when you have a coordinate pair (longitude, latitude) and need both PSAP and AHJ information. "
-                "Do NOT use if you only need PSAP data — use psap_location instead (lighter response). "
-                "Do NOT use if you have a street address rather than coordinates — use psap_ahj_address instead. "
-                "Do NOT use if lookup is by FCC ID — use psap_ahj_fccid instead. "
-                "Only works for coordinates within the United States.\n\n"
-                "Output: Object with PSAP name, phone, fccId, AHJ names "
-                "and other details."
-            ),
-            inputSchema={
-                "type": "object",
-                "properties": {
-                    "location": _PSAP_LOCATION_SCHEMA
-                },
-                "required": ["location"]
-            }
-        ),
-        Tool(
-            name="psap_ahj_fccid",
-            description=(
-                "Retrieve PSAP (Public Safety Answering Point / 911 dispatch center) and "
-                "AHJ (Authority Having Jurisdiction) details for a PSAP identified by its FCC (Federal Communications Commission) ID. "
-                "Use this tool only when you already have a specific FCC PSAP ID and need its full record. "
-                "Do NOT use if you are starting from an address — use psap_ahj_address instead. "
-                "Do NOT use if you are starting from coordinates — use psap_ahj_location instead. "
-                "FCC IDs are obtained from prior psap_address, psap_location, or related calls. "
-                "Only works for US PSAP entities.\n\n"
-                "Output: Object with PSAP name, phone, fccID, AHJ names and other details for the specified FCC ID."
-            ),
-            inputSchema={
-                "type": "object",
-                "properties": {
+                    "address": {
+                        "type": "object",
+                        "description": "Structured US address for PSAP lookup.",
+                        "properties": {
+                            "addressLines": {
+                                "type": "array",
+                                "items": {"type": "string"},
+                                "description": "Street address lines (e.g., ['860 White Plains Road']).",
+                                "minItems": 1
+                            },
+                            "city": {"type": "string", "description": "City name (e.g., 'Trumbull')."},
+                            "admin1": {"type": "string", "description": "State abbreviation (e.g., 'CT')."},
+                            "postalCode": {"type": "string", "description": "ZIP code (e.g., '06611')."},
+                        }
+                    },
+                    "location": {
+                        "type": "object",
+                        "description": "Geographic coordinates for PSAP lookup.",
+                        "properties": {
+                            "coordinates": {
+                                "type": "array",
+                                "items": {"type": "number"},
+                                "description": "Coordinates as [longitude, latitude] (e.g., [-71.0589, 42.3601]). WGS 84 datum/EPSG:4326 coordinate system.",
+                                "minItems": 2,
+                                "maxItems": 2
+                            }
+                        },
+                        "required": ["coordinates"]
+                    },
                     "fcc_id": {
                         "type": "string",
-                        "description": "The FCC-assigned PSAP identifier (e.g., '1404'). "
-                                       "Obtain this value from a prior psap_address or psap_location call."
+                        "description": (
+                            "The FCC-assigned PSAP identifier (e.g., '1404'). "
+                            "Obtain this value from a prior find_emergency_services call."
+                        )
+                    },
+                    "include_ahj": {
+                        "type": "boolean",
+                        "default": True,
+                        "description": (
+                            "When true (default), returns both PSAP and AHJ data. "
+                            "When false, returns only PSAP data (lighter response). "
+                            "Ignored when fcc_id is provided (FCC ID lookup always includes AHJ)."
+                        )
                     }
                 },
-                "required": ["fcc_id"]
+                "oneOf": [
+                    {"required": ["address"]},
+                    {"required": ["location"]},
+                    {"required": ["fcc_id"]}
+                ]
             }
         ),
     ]

--- a/dis-locate-apis-v2/mcp_servers/tools/timezone.py
+++ b/dis-locate-apis-v2/mcp_servers/tools/timezone.py
@@ -1,6 +1,6 @@
 """
 Timezone Tools Module
-Contains 2 tools for timezone lookups by address and coordinates
+Contains 1 tool for timezone lookups by address or coordinates
 """
 from mcp.types import Tool
 from mcp_servers.tools.base_tool import handle_tool_call  # noqa: F401
@@ -10,24 +10,14 @@ def get_tools() -> list[Tool]:
     """Returns list of timezone tool definitions"""
     return [
         Tool(
-            name="timezone_addresses",
-            description=(
-                "Look up the timezone for one or more addresses, including UTC offset and DST status, "
-                "at a specific UTC time. "
-                "Returns the IANA timezone name (e.g., 'America/New_York'), UTC offset in hours and minutes, "
-                "and whether daylight saving time (DST) is in effect at the given timestamp. "
-                "Use this tool when you have street addresses and need timezone information. "
-                "Do NOT use if you have coordinates instead of addresses — use timezone_locations instead. "
-                "Supports multiple addresses in a single call.\n\n"
-                "Output: Array of timezone result objects (one per input address), each containing "
-                "the IANA timezone ID, UTC offset, DST status, and the input address id for correlation."
-            ),
+            name="get_timezones",
+            description="""Look up the timezone for one or more addresses or geographic coordinates (longitude, latitude), including UTC offset and DST status, at a specific UTC point in time. Returns the IANA timezone name (e.g., 'America/New_York'), UTC offset in hours and minutes, and whether daylight saving time (DST) is in effect at the given timestamp. Provide either 'addresses' (when you have street addresses) or 'locations' (when you have coordinate pairs) — not both. Supports multiple entries in a single call.
+
+Output: Array of timezone result objects (one per input), each containing the IANA timezone ID, UTC offset, DST status, and the input id for correlation.""",
             inputSchema={
                 "type": "object",
-                "properties": {
-                    "data": {
-                        "type": "object",
-                        "description": "Timezone lookup request payload.",
+                "oneOf": [
+                    {
                         "properties": {
                             "addresses": {
                                 "type": "array",
@@ -70,30 +60,8 @@ def get_tools() -> list[Tool]:
                             }
                         },
                         "required": ["addresses"]
-                    }
-                },
-                "required": ["data"]
-            }
-        ),
-        Tool(
-            name="timezone_locations",
-            description=(
-                "Look up the timezone for one or more geographic coordinates (longitude, latitude), "
-                "including UTC offset and DST status, at a specific UTC point in time. "
-                "Returns the IANA timezone name (e.g., 'America/Chicago'), UTC offset in hours and minutes, "
-                "and whether daylight saving time (DST) is in effect at the given timestamp. "
-                "Use this tool when you have coordinate pairs and need timezone information. "
-                "Do NOT use if you have street addresses instead of coordinates — use timezone_addresses instead. "
-                "Supports multiple coordinate pairs in a single call.\n\n"
-                "Output: Array of timezone result objects (one per input coordinate), each containing "
-                "the IANA timezone ID, UTC offset, DST status, and the input id for correlation."
-            ),
-            inputSchema={
-                "type": "object",
-                "properties": {
-                    "data": {
-                        "type": "object",
-                        "description": "Timezone lookup request payload.",
+                    },
+                    {
                         "properties": {
                             "locations": {
                                 "type": "array",
@@ -134,8 +102,7 @@ def get_tools() -> list[Tool]:
                         },
                         "required": ["locations"]
                     }
-                },
-                "required": ["data"]
+                ]
             }
         ),
     ]

--- a/dis-locate-apis-v2/mcp_servers/tools/timezone.py
+++ b/dis-locate-apis-v2/mcp_servers/tools/timezone.py
@@ -16,92 +16,86 @@ def get_tools() -> list[Tool]:
 Output: Array of timezone result objects (one per input), each containing the IANA timezone ID, UTC offset, DST status, and the input id for correlation.""",
             inputSchema={
                 "type": "object",
-                "oneOf": [
-                    {
-                        "properties": {
-                            "addresses": {
-                                "type": "array",
-                                "description": "List of addresses to resolve timezone for.",
-                                "items": {
-                                    "type": "object",
-                                    "properties": {
-                                        "timestamp": {
-                                            "type": "integer",
-                                            "description": (
-                                                "UTC timestamp in milliseconds for which to evaluate timezone/DST status "
-                                                "(e.g., 1691138974831). If omitted, the current server time is used."
-                                            )
-                                        },
-                                        "address": {
-                                            "type": "object",
-                                            "description": "Structured address object.",
-                                            "properties": {
-                                                "id": {
-                                                    "type": "string",
-                                                    "description": "Client-supplied identifier to correlate this input with its output (e.g., '1')."
-                                                },
-                                                "addressLines": {
-                                                    "type": "array",
-                                                    "items": {"type": "string"},
-                                                    "description": "Street address lines (e.g., ['1700 District Ave, Burlington, MA']).",
-                                                    "minItems": 1
-                                                },
-                                                "country": {
-                                                    "type": "string",
-                                                    "description": "ISO 3166-1 compliant country code (alpha-2, alpha-3, or numeric). (e.g., 'USA')."
-                                                }
-                                            },
-                                            "required": ["country"]
-                                        }
-                                    },
-                                    "required": ["timestamp", "address"]
+                "properties": {
+                    "addresses": {
+                        "type": "array",
+                        "description": "List of addresses to resolve timezone for. Provide this OR 'locations', not both.",
+                        "items": {
+                            "type": "object",
+                            "properties": {
+                                "timestamp": {
+                                    "type": "integer",
+                                    "description": (
+                                        "UTC timestamp in milliseconds for which to evaluate timezone/DST status "
+                                        "(e.g., 1691138974831). If omitted, the current server time is used."
+                                    )
                                 },
-                                "minItems": 1
-                            }
-                        },
-                        "required": ["addresses"]
-                    },
-                    {
-                        "properties": {
-                            "locations": {
-                                "type": "array",
-                                "description": "List of coordinate pairs to resolve timezone for.",
-                                "items": {
+                                "address": {
                                     "type": "object",
+                                    "description": "Structured address object.",
                                     "properties": {
                                         "id": {
                                             "type": "string",
                                             "description": "Client-supplied identifier to correlate this input with its output (e.g., '1')."
                                         },
-                                        "timestamp": {
-                                            "type": "integer",
-                                            "description": (
-                                                "UTC timestamp in milliseconds for which to evaluate timezone/DST status "
-                                                "(e.g., 1691138974831). If omitted, the current server time is used."
-                                            )
+                                        "addressLines": {
+                                            "type": "array",
+                                            "items": {"type": "string"},
+                                            "description": "Street address lines (e.g., ['1700 District Ave, Burlington, MA']).",
+                                            "minItems": 1
                                         },
-                                        "geometry": {
-                                            "type": "object",
-                                            "description": "GeoJSON-style geometry object with coordinates.",
-                                            "properties": {
-                                                "coordinates": {
-                                                    "type": "array",
-                                                    "items": {"type": "number"},
-                                                    "description": "Coordinates as [longitude, latitude] WGS 84 datum/EPSG:4326 coordinate system (e.g., [-71.0589, 42.3601]).",
-                                                    "minItems": 2,
-                                                    "maxItems": 2
-                                                }
-                                            },
-                                            "required": ["coordinates"]
+                                        "country": {
+                                            "type": "string",
+                                            "description": "ISO 3166-1 compliant country code (alpha-2, alpha-3, or numeric). (e.g., 'USA')."
                                         }
                                     },
-                                    "required": ["timestamp", "geometry"]
-                                },
-                                "minItems": 1
-                            }
+                                    "required": ["country"]
+                                }
+                            },
+                            "required": ["timestamp", "address"]
                         },
-                        "required": ["locations"]
+                        "minItems": 1
+                    },
+                    "locations": {
+                        "type": "array",
+                        "description": "List of coordinate pairs to resolve timezone for. Provide this OR 'addresses', not both.",
+                        "items": {
+                            "type": "object",
+                            "properties": {
+                                "id": {
+                                    "type": "string",
+                                    "description": "Client-supplied identifier to correlate this input with its output (e.g., '1')."
+                                },
+                                "timestamp": {
+                                    "type": "integer",
+                                    "description": (
+                                        "UTC timestamp in milliseconds for which to evaluate timezone/DST status "
+                                        "(e.g., 1691138974831). If omitted, the current server time is used."
+                                    )
+                                },
+                                "geometry": {
+                                    "type": "object",
+                                    "description": "GeoJSON-style geometry object with coordinates.",
+                                    "properties": {
+                                        "coordinates": {
+                                            "type": "array",
+                                            "items": {"type": "number"},
+                                            "description": "Coordinates as [longitude, latitude] WGS 84 datum/EPSG:4326 coordinate system (e.g., [-71.0589, 42.3601]).",
+                                            "minItems": 2,
+                                            "maxItems": 2
+                                        }
+                                    },
+                                    "required": ["coordinates"]
+                                }
+                            },
+                            "required": ["timestamp", "geometry"]
+                        },
+                        "minItems": 1
                     }
+                },
+                "oneOf": [
+                    {"required": ["addresses"]},
+                    {"required": ["locations"]}
                 ]
             }
         ),

--- a/dis-locate-apis-v2/mcp_servers/tools/verification.py
+++ b/dis-locate-apis-v2/mcp_servers/tools/verification.py
@@ -1,6 +1,6 @@
 """
 Verification Tools Module
-Contains 5 tools for email verification, phone validation, and name parsing
+Contains 3 tools for email verification, phone validation, and name parsing
 """
 from mcp.types import Tool
 from mcp_servers.tools.base_tool import handle_tool_call  # noqa: F401
@@ -10,68 +10,43 @@ def get_tools() -> list[Tool]:
     """Returns list of verification tool definitions"""
     return [
         Tool(
-            name="verify_email",
-            description=(
-                "Verify a single email address for deliverability, validity, and format correctness. "
-                "Checks syntax, domain existence, and MX record reachability to determine "
-                "whether the address is likely deliverable. "
-                "Use this tool when you need to validate one email address before sending or storing it. "
-                "Do NOT use for bulk validation of multiple emails — use verify_batch_emails instead "
-                "(more efficient for 2 or more addresses). "
-                "Does not send any email; this is a read-only verification call.\n\n"
-                "Output: Object with verification result including validity status "
-                "(e.g., valid, invalid, risky, unknown), reason code, "
-                "and domain details."
-            ),
-            inputSchema={
-                "type": "object",
-                "properties": {
-                    "email": {
-                        "type": "string",
-                        "description": "Email address to verify (e.g., 'john.doe@company.com').",
-                        "format": "email"
-                    }
-                },
-                "required": ["email"]
-            }
-        ),
-        Tool(
-            name="verify_batch_emails",
-            description=(
-                "Verify multiple email addresses for deliverability and validity in a single batch call. "
-                "Checks syntax, domain existence, and MX record reachability for each address. "
-                "Use this tool when you have two or more email addresses to validate "
-                "(more efficient than repeated verify_email calls). "
-                "Do NOT use for a single email — use verify_email instead. "
-                "Maximum batch size: 10 addresses per call. "
-                "Does not send any email; this is a read-only verification call.\n\n"
-                "Output: Array of verification result objects (one per input), each containing validity status, "
-                "reason code. "
-                "Each result includes the 'id' from the corresponding input for correlation."
-            ),
+            name="verify_emails",
+            description="""Verify one or more email addresses for deliverability, validity, and format correctness. Checks syntax, domain existence, and MX record reachability to determine whether each address is likely deliverable. Accepts a single email string or an array of email objects (max 10). A single string is automatically handled as a one-item batch. Does not send any email; this is a read-only verification call.
+
+Output: Array of verification result objects (one per input), each containing validity status (e.g., valid, invalid, risky, unknown), domain and other details. Each result includes the 'id' from the corresponding input for correlation when provided.""",
             inputSchema={
                 "type": "object",
                 "properties": {
                     "emails": {
-                        "type": "array",
-                        "description": "List of email addresses to verify. Maximum 10 per call.",
-                        "items": {
-                            "type": "object",
-                            "properties": {
-                                "id": {
-                                    "type": "string",
-                                    "description": "Client-supplied identifier to correlate this input with its output (e.g., '1')."
-                                },
-                                "email": {
-                                    "type": "string",
-                                    "description": "Email address to verify (e.g., 'john@company.com').",
-                                    "format": "email"
-                                }
+                        "description": "Email address(es) to verify. Provide a single email string or an array of email objects (max 10).",
+                        "oneOf": [
+                            {
+                                "type": "string",
+                                "description": "A single email address to verify (e.g., 'john.doe@company.com').",
+                                "format": "email"
                             },
-                            "required": ["email"]
-                        },
-                        "minItems": 1,
-                        "maxItems": 10
+                            {
+                                "type": "array",
+                                "description": "List of email addresses to verify. Maximum 10 per call.",
+                                "items": {
+                                    "type": "object",
+                                    "properties": {
+                                        "id": {
+                                            "type": "string",
+                                            "description": "Client-supplied identifier to correlate this input with its output (e.g., '1')."
+                                        },
+                                        "email": {
+                                            "type": "string",
+                                            "description": "Email address to verify (e.g., 'john@company.com').",
+                                            "format": "email"
+                                        }
+                                    },
+                                    "required": ["email"]
+                                },
+                                "minItems": 1,
+                                "maxItems": 10
+                            }
+                        ]
                     }
                 },
                 "required": ["emails"]
@@ -79,15 +54,9 @@ def get_tools() -> list[Tool]:
         ),
         Tool(
             name="parse_name",
-            description=(
-                "Parse a full personal name, or business name. Personal names parsed  into: title/salutation, first name, middle name, last name, and suffix."
-                "Use this tool when you need to decompose a combined name string for data processing, "
-                "personalization, or storage in structured fields. "
-                "Do NOT use if you need address parsing — use parse_address or parse_address_batch instead. "
-                "Works best with Western-style name formats; accuracy may vary for non-Western names.\n\n"
-                "Output: Object with extracted name components: "
-                "title (e.g., 'Dr.'), firstName, middleName, lastName, and suffix (e.g., 'Jr.')."
-            ),
+            description="""Parse a full personal name, or business name. Personal names parsed  into: title/salutation, first name, middle name, last name, and suffix.Use this tool when you need to decompose a combined name string for data processing, personalization, or storage in structured fields. Do NOT use if you need address parsing — use parse_address or parse_address_batch instead. Works best with Western-style name formats; accuracy may vary for non-Western names.
+
+Output: Object with extracted name components: title (e.g., 'Dr.'), firstName, middleName, lastName, and suffix (e.g., 'Jr.').""",
             inputSchema={
                 "type": "object",
                 "properties": {
@@ -107,62 +76,35 @@ def get_tools() -> list[Tool]:
             }
         ),
         Tool(
-            name="validate_phone",
-            description=(
-                "Validate a single phone number for format correctness, country assignment, "
-                "and line type (mobile, landline, VoIP, toll-free, etc.). "
-                "Use this tool when you need to validate one phone number before storing or dialing it. "
-                "Do NOT use for bulk validation of multiple numbers — use validate_batch_phones instead "
-                "(more efficient for 2 or more numbers). "
-                "Provide the country code to improve accuracy; without it, the service will attempt to infer the country.\n\n"
-                "Output: Object with validation result including validity status, formatted phone number "
-                "(E.164 or local format), country code, line type (mobile/landline/VoIP/toll-free), "
-                "and carrier information where available."
-            ),
+            name="validate_phones",
+            description="""Validate one or more phone numbers for format correctness, country assignment, and line type (mobile, landline, VoIP, toll-free, etc.). Accepts a single phone object or an array of phone objects (max 10). A single object is automatically handled as a one-item batch. Provide the country code to improve accuracy; without it, the service will attempt to infer the country.
+
+Output: Array of validation result objects (one per input), each containing validity status, formatted phone number (E.164 or local format), country code, line type, and carrier information where available. Each result includes the 'id' from the corresponding input for correlation when provided.""",
             inputSchema={
                 "type": "object",
                 "properties": {
-                    "data": {
-                        "type": "object",
-                        "description": "Phone number validation request.",
-                        "properties": {
-                            "phoneNumber": {
-                                "type": "string",
-                                "description": "Phone number to validate. Can include digits only or common formatting characters (e.g., '4144654885' or '(414) 465-4885')."
+                    "phones": {
+                        "description": "Phone number(s) to validate. Provide a single phone object or an array of phone objects (max 10).",
+                        "oneOf": [
+                            {
+                                "type": "object",
+                                "title": "Single phone number",
+                                "description": "A single phone number to validate.",
+                                "properties": {
+                                    "phoneNumber": {
+                                        "type": "string",
+                                        "description": "Phone number to validate. Can include digits only or common formatting characters (e.g., '4144654885' or '(414) 465-4885')."
+                                    },
+                                    "country": {
+                                        "type": "string",
+                                        "description": "Country code in ISO2 or ISO3 format (e.g., 'US', 'GB', 'DE'). Strongly recommended for accurate validation."
+                                    }
+                                },
+                                "required": ["phoneNumber"]
                             },
-                            "country": {
-                                "type": "string",
-                                "description": "Country code in ISO2 or ISO3 format to assist in phone number verification. e.g., 'US', 'GB', 'DE'. Strongly recommended for accurate validation."
-                            }
-                        },
-                        "required": ["phoneNumber"]
-                    }
-                },
-                "required": ["data"]
-            }
-        ),
-        Tool(
-            name="validate_batch_phones",
-            description=(
-                "Validate multiple phone numbers for format correctness, country assignment, "
-                "and line type in a single batch call. "
-                "Use this tool when you have two or more phone numbers to validate "
-                "(more efficient than repeated validate_phone calls). "
-                "Do NOT use for a single number — use validate_phone instead. "
-                "Maximum batch size: 10 phone numbers per call.\n\n"
-                "Output: Array of validation result objects (one per input), each containing validity status, "
-                "formatted phone number, country code, line type, and carrier information. "
-                "Each result includes the 'id' from the corresponding input for correlation."
-            ),
-            inputSchema={
-                "type": "object",
-                "properties": {
-                    "data": {
-                        "type": "object",
-                        "description": "Batch phone validation request.",
-                        "properties": {
-                            "phoneNumbers": {
+                            {
                                 "type": "array",
+                                "title": "Batch phone numbers",
                                 "description": "List of phone numbers to validate. Maximum 10 per call.",
                                 "items": {
                                     "type": "object",
@@ -185,11 +127,10 @@ def get_tools() -> list[Tool]:
                                 "minItems": 1,
                                 "maxItems": 10
                             }
-                        },
-                        "required": ["phoneNumbers"]
+                        ]
                     }
                 },
-                "required": ["data"]
+                "required": ["phones"]
             }
         ),
     ]

--- a/dis-locate-apis-v2/precisely/geocoding.py
+++ b/dis-locate-apis-v2/precisely/geocoding.py
@@ -89,75 +89,102 @@ class GeocodingMixin:
             logger.error(f"Address verification error: {e}")
             return self._build_error("Address verification", e)
 
-    def parse_address(self, address: str, **kwargs) -> Dict[str, Any]:
-        """Parse a single-line address into structured components"""
-        try:
-            url = f"{self.base_url}/v1/address/parse"
-            json_data = {"address": address}
-            logger.debug(f"[parse_address] Request payload: {json.dumps(json_data, indent=2)}")
-            response = self.session.post(url, json=json_data)
-            logger.debug(f"[parse_address] Raw response: {response.text}")
-            response.raise_for_status()
-            return response.json()
-        except Exception as e:
-            logger.error(f"Parse address error: {e}")
-            return self._build_error("Parse address", e)
+    def parse_addresses(self, addresses, **kwargs) -> Dict[str, Any]:
+        """Parse one or more free-text addresses into structured components.
 
-    def parse_address_batch(self, addresses: List[Dict], **kwargs) -> Dict[str, Any]:
-        """Parse a batch of addresses into structured components"""
+        Accepts a single address string or a list of address objects.
+        Always uses the batch endpoint; a single string is auto-wrapped.
+
+        Args:
+            addresses: A single address string (e.g., "1700 District Ave #300, Burlington, MA 01803"),
+                or a list of dicts with 'address' (and optional 'id') keys.
+                Maximum 10 addresses per call.
+        """
         try:
             url = f"{self.base_url}/v1/address/parse/batch"
-            json_data = {"addresses": addresses}
-            logger.debug(f"[parse_address_batch] Request payload: {json.dumps(json_data, indent=2)}")
-            response = self.session.post(url, json=json_data)
-            logger.debug(f"[parse_address_batch] Raw response: {response.text}")
-            response.raise_for_status()
-            return response.json()
-        except Exception as e:
-            logger.error(f"Parse address batch error: {e}")
-            return self._build_error("Parse address batch", e)
 
-    def autocomplete(self, address: Dict, preferences: Dict = None, **kwargs) -> Dict[str, Any]:
-        """Address autocomplete suggestions"""
-        try:
-            url = f"{self.base_url}/v1/autocomplete"
-            json_data = {"address": address, "preferences": preferences or {}}
-            logger.debug(f"[autocomplete] Request payload: {json.dumps(json_data, indent=2)}")
-            response = self.session.post(url, json=json_data)
-            logger.debug(f"[autocomplete] Raw response: {response.text}")
-            response.raise_for_status()
-            return response.json()
-        except Exception as e:
-            logger.error(f"Autocomplete error: {e}")
-            return self._build_error("Autocomplete", e)
+            # Normalize input → list of {"address": ...} dicts
+            if isinstance(addresses, str):
+                processed_addresses = [{"address": addresses}]
+            elif isinstance(addresses, list):
+                processed_addresses = addresses
+            else:
+                return self._build_error(
+                    "Address parsing",
+                    ValueError(
+                        "'addresses' must be a string (single address) or a list of "
+                        "dicts with 'address' key (multiple addresses)."
+                    ),
+                )
 
-    def autocomplete_postal_city(self, address: Dict, preferences: Dict = None, **kwargs) -> Dict[str, Any]:
-        """Autocomplete postal city API"""
-        try:
-            url = f"{self.base_url}/v1/autocomplete/postal-city"
-            json_data = {"address": address, "preferences": preferences or {}}
-            logger.debug(f"[autocomplete_postal_city] Request payload: {json.dumps(json_data, indent=2)}")
-            response = self.session.post(url, json=json_data)
-            logger.debug(f"[autocomplete_postal_city] Raw response: {response.text}")
-            response.raise_for_status()
-            return response.json()
-        except Exception as e:
-            logger.error(f"Autocomplete postal city error: {e}")
-            return self._build_error("Autocomplete postal city", e)
+            if not processed_addresses:
+                return self._build_error(
+                    "Address parsing",
+                    ValueError("No addresses provided."),
+                )
 
-    def autocomplete_v2(self, address: Dict, preferences: Dict = None, **kwargs) -> Dict[str, Any]:
-        """Express autocomplete API (V2)"""
-        try:
-            url = f"{self.base_url}/v1/express-autocomplete"
-            json_data = {"address": address, "preferences": preferences or {}}
-            logger.debug(f"[autocomplete_v2] Request payload: {json.dumps(json_data, indent=2)}")
+            json_data = {"addresses": processed_addresses}
+            logger.debug(f"[parse_addresses] Request payload: {json.dumps(json_data, indent=2)}")
             response = self.session.post(url, json=json_data)
-            logger.debug(f"[autocomplete_v2] Raw response: {response.text}")
+            logger.debug(f"[parse_addresses] Raw response: {response.text}")
             response.raise_for_status()
             return response.json()
         except Exception as e:
-            logger.error(f"Autocomplete v2 error: {e}")
-            return self._build_error("Autocomplete v2", e)
+            logger.error(f"Address parsing error: {e}")
+            return self._build_error("Address parsing", e)
+
+    def autocomplete_address(
+        self,
+        address: Dict,
+        preferences: Dict = None,
+        express: bool = False,
+        **kwargs,
+    ) -> Dict[str, Any]:
+        """Autocomplete addresses, postal codes, or city names.
+
+        Routes to the correct endpoint based on address structure:
+        - addressLines present → street address autocomplete (standard or express)
+        - postAddress present → postal code / city name autocomplete
+
+        Args:
+            address: Address input — either {addressLines, country, ...} for street
+                or {postAddress, country, type?} for postal/city.
+            preferences: Optional preferences (e.g., maxResults).
+            express: When True, uses the faster express engine for street address
+                autocomplete. Ignored for postal/city lookups.
+        """
+        is_street = "addressLines" in address
+        is_postal = "postAddress" in address
+
+        if not is_street and not is_postal:
+            return {
+                "error": {
+                    "message": (
+                        "Address must contain either 'addressLines' (for street autocomplete) "
+                        "or 'postAddress' (for postal/city autocomplete)."
+                    ),
+                    "error_type": "ValidationError",
+                }
+            }
+
+        try:
+            if is_postal:
+                url = f"{self.base_url}/v1/autocomplete/postal-city"
+            elif express:
+                url = f"{self.base_url}/v1/express-autocomplete"
+            else:
+                url = f"{self.base_url}/v1/autocomplete"
+
+            json_data = {"address": address, "preferences": preferences or {}}
+            logger.debug(f"[autocomplete_address] POST {url}")
+            logger.debug(f"[autocomplete_address] Request payload: {json.dumps(json_data, indent=2)}")
+            response = self.session.post(url, json=json_data)
+            logger.debug(f"[autocomplete_address] Raw response: {response.text}")
+            response.raise_for_status()
+            return response.json()
+        except Exception as e:
+            logger.error(f"Autocomplete address error: {e}")
+            return self._build_error("Autocomplete address", e)
 
     def lookup(self, keys: List[Dict], preferences: Dict = None, **kwargs) -> Dict[str, Any]:
         """Lookup address details by PreciselyID"""

--- a/dis-locate-apis-v2/precisely/map_services.py
+++ b/dis-locate-apis-v2/precisely/map_services.py
@@ -1,4 +1,4 @@
-"""OGC Features, WMS, and WMTS API methods (15 tools)."""
+"""OGC Features, WMS, and WMTS API methods (8 tools)."""
 
 import base64
 import json
@@ -12,62 +12,6 @@ class MapServicesMixin:
     # ========================================
     # OGC Features APIs
     # ========================================
-
-    def ogc_landing_page(self, **kwargs) -> Dict[str, Any]:
-        """The landing page provides links to essential API resources, including:
-- **API Definition:** A machine-readable specification of the API.
-- **Conformance Declaration:** A list of standards that the API conforms to.
-- **Feature Collections:** Information and links to the available feature collections in the dataset.
-
-Use this endpoint to quickly navigate and explore the API's capabilities.
-
-        Args:
-            **kwargs: Additional keyword arguments passed to the API.
-
-        Returns:
-            Dict[str, Any]: LandingPageResponse with keys 'title' (str), 'description' (str),
-                and 'links' (list of Link objects with href, rel, type, title).
-
-        Example:
-            ogc_landing_page()
-        """
-        try:
-            url = f"{self.base_url}/v1/ogcapi/enrich/"
-            logger.debug(f"[ogc_landing_page] GET {url}")
-            response = self.session.get(url)
-            logger.debug(f"[ogc_landing_page] Raw response: {response.text}")
-            response.raise_for_status()
-            return response.json()
-        except Exception as e:
-            logger.error(f"OGC landing page error: {e}")
-            return self._build_error("OGC landing page", e)
-
-    def ogc_api_definition(self, **kwargs) -> Dict[str, Any]:
-        """This endpoint retrieves the complete OpenAPI definition for the API. The response is a machine-readable specification that describes all available endpoints, request/response schemas, and security configurations.
-
-- **Format:** The API definition conforms to the OpenAPI 3.0.1 standard.
-
-        Args:
-            **kwargs: Additional keyword arguments passed to the API.
-
-        Returns:
-            Dict[str, Any]: Complete OpenAPI 3.0.1 definition as a JSON object with keys 'openapi' (str),
-                'info' (dict), 'servers' (list), 'paths' (dict), and 'components' (dict).
-
-        Example:
-            ogc_api_definition()
-        """
-        try:
-            url = f"{self.base_url}/v1/ogcapi/enrich/api"
-            headers = {"Accept": "application/vnd.oai.openapi+json;version=3.0"}
-            logger.debug(f"[ogc_api_definition] GET {url}")
-            response = self.session.get(url, headers=headers)
-            logger.debug(f"[ogc_api_definition] Raw response: {response.text}")
-            response.raise_for_status()
-            return response.json()
-        except Exception as e:
-            logger.error(f"OGC API definition error: {e}")
-            return self._build_error("OGC API definition", e)
 
     def ogc_functions(self, **kwargs) -> Dict[str, Any]:
         """This endpoint returns a list of available spatial functions within the API.
@@ -94,32 +38,6 @@ Use this endpoint to quickly navigate and explore the API's capabilities.
         except Exception as e:
             logger.error(f"OGC functions error: {e}")
             return self._build_error("OGC functions", e)
-
-    def ogc_conformance(self, **kwargs) -> Dict[str, Any]:
-        """This endpoint returns the conformance declaration for the API. The conformance declaration is a list of all conformance classes specified in a standard that the server adheres to. It helps clients determine whether the API meets the required standards and their own requirements.
-
-- **Purpose:** Provides a comprehensive list of conformance classes to verify the API's compliance with OGC API standards and additional specifications.
-- **Standards:** Includes OGC API conformance classes and any extra specifications the API supports.
-
-        Args:
-            **kwargs: Additional keyword arguments passed to the API.
-
-        Returns:
-            Dict[str, Any]: ConformancePageResponse with key 'conformsTo' (list of conformance class URI strings).
-
-        Example:
-            ogc_conformance()
-        """
-        try:
-            url = f"{self.base_url}/v1/ogcapi/enrich/conformance"
-            logger.debug(f"[ogc_conformance] GET {url}")
-            response = self.session.get(url)
-            logger.debug(f"[ogc_conformance] Raw response: {response.text}")
-            response.raise_for_status()
-            return response.json()
-        except Exception as e:
-            logger.error(f"OGC conformance error: {e}")
-            return self._build_error("OGC conformance", e)
 
     def ogc_collections(self, **kwargs) -> Dict[str, Any]:
         """This endpoint returns the list of feature collections available on the server. Each collection represents a spatial dataset that can be queried and provides essential metadata, including:
@@ -255,14 +173,16 @@ This metadata is essential for clients to build dynamic query interfaces and val
             logger.error(f"OGC collection queryables error: {e}")
             return self._build_error("OGC collection queryables", e)
 
-    def ogc_collection_items(self, collectionId: str, **kwargs) -> Dict[str, Any]:
+    def ogc_collection_items(self, collectionId: str, featureId: str = None, **kwargs) -> Dict[str, Any]:
         """Fetch features of the feature collection with id `{collectionId}`.
 
 Every feature in a dataset belongs to a collection. A dataset may consist of multiple feature collections, each representing a group of features that share a common schema and type.
 
 The **collection id** is a unique identifier for the spatial dataset and is used to reference a specific collection within the API.
 
-Additional capabilities include:
+When a featureId is provided, retrieves a single feature in GeoJSON format.
+
+When no featureId is provided, additional capabilities include:
 - **Filtering:** Supports attribute-based filtering using CQL (Common Query Language).
 - **Pagination:** Use `limit` and `offset` parameters to paginate results.
 - **Spatial Queries:**
@@ -271,6 +191,7 @@ Additional capabilities include:
 
         Args:
             collectionId (str): Unique identifier of the collection.
+            featureId (str, optional): Unique feature identifier. When provided, returns a single feature.
             **kwargs: Additional keyword arguments passed to the API.
                 limit (str): Number of items to return (max: 10,000).
                 offset (str): Offset for pagination.
@@ -284,13 +205,19 @@ Additional capabilities include:
 
         Example:
             ogc_collection_items(collectionId="properties/buildings", limit=100, offset=0)
+            ogc_collection_items(collectionId="properties/buildings", featureId="1")
         """
         try:
-            url = f"{self.base_url}/v1/ogcapi/enrich/collections/{collectionId}/items"
-            params = {k: kwargs[k] for k in ["limit", "offset", "bbox", "filter"] if k in kwargs}
+            if featureId:
+                url = f"{self.base_url}/v1/ogcapi/enrich/collections/{collectionId}/items/{featureId}"
+                params = {}
+            else:
+                url = f"{self.base_url}/v1/ogcapi/enrich/collections/{collectionId}/items"
+                params = {k: kwargs[k] for k in ["limit", "offset", "bbox", "filter"] if k in kwargs}
             headers = {"Accept": "application/geo+json"}
             logger.debug(f"[ogc_collection_items] GET {url}")
-            logger.debug(f"[ogc_collection_items] Request params: {params}")
+            if params:
+                logger.debug(f"[ogc_collection_items] Request params: {params}")
             response = self.session.get(url, params=params, headers=headers)
             logger.debug(f"[ogc_collection_items] Raw response: {response.text}")
             response.raise_for_status()
@@ -299,48 +226,20 @@ Additional capabilities include:
             logger.error(f"OGC collection items error: {e}")
             return self._build_error("OGC collection items", e)
 
-    def ogc_feature_by_id(self, collectionId: str, featureId: str, **kwargs) -> Dict[str, Any]:
-        """Retrieves a single feature in GeoJSON format,
-
-        Args:
-            collectionId (str): Unique collection identifier
-            featureId (str): Unique feature identifier
-            **kwargs: Additional keyword arguments passed to the API.
-
-        Returns:
-            Dict[str, Any]: FeatureCollectionResponse (GeoJSON) with keys 'type' (str), 'features'
-                (list containing the single Feature with properties, geometry, and id), 'timeStamp' (str),
-                and 'links' (list of Link objects).
-
-        Example:
-            ogc_feature_by_id(collectionId="properties/buildings", featureId="1")
-        """
-        try:
-            url = f"{self.base_url}/v1/ogcapi/enrich/collections/{collectionId}/items/{featureId}"
-            headers = {"Accept": "application/geo+json"}
-            logger.debug(f"[ogc_feature_by_id] GET {url}")
-            response = self.session.get(url, headers=headers)
-            logger.debug(f"[ogc_feature_by_id] Raw response: {response.text}")
-            response.raise_for_status()
-            return response.json()
-        except Exception as e:
-            logger.error(f"OGC feature by ID error: {e}")
-            return self._build_error("OGC feature by ID", e)
-
     # ========================================
     # WMS (Web Map Service) APIs
     # ========================================
 
-    def wms_get_request(self, **kwargs) -> Dict[str, Any]:
-        """Processes WMS requests: GetCapabilities, GetMap, GetFeatureInfo. WMS service errors (ServiceExceptionReport) with HTTP 2xx are raised as exceptions and returned as {"error": <xml>}.
+    def wms_request(self, **kwargs) -> Dict[str, Any]:
+        """Processes WMS requests: GetCapabilities, GetMap, GetFeatureInfo via GET; GetMap with custom SLD styling via POST (automatically triggered when SLD_BODY is provided). WMS service errors (ServiceExceptionReport) with HTTP 2xx are raised as exceptions and returned as {"error": <xml>}.
 
         Args:
             **kwargs: Additional keyword arguments passed to the API.
                 REQUEST (str): WMS request type
                 SERVICE (str): Service type
-                VERSION (str): WMS version
-                crs (str): crs
-                srs (str): srs
+                VERSION (str): WMS version ('1.3.0' uses crs; '1.1.1' uses srs)
+                crs (str): Coordinate reference system for WMS 1.3.0 (e.g. 'CRS:84', 'EPSG:4326', 'EPSG:3857')
+                srs (str): Spatial reference system for WMS 1.1.1 (e.g. 'EPSG:4326', 'EPSG:3857')
                 BBOX (str): BBOX
                 width (str): width
                 height (str): height
@@ -353,12 +252,16 @@ Additional capabilities include:
                 Y (str): Y
                 Feature_Count (str): Feature_Count
                 PIXELSEARCHRADIUS (str): PIXELSEARCHRADIUS
-                STYLES (str): STYLES
+                STYLES (str): Comma-separated list of style names, one per requested layer.
                 FORMAT (str): FORMAT
                 TRANSPARENT (str): TRANSPARENT
-                BGCOLOR (str): BGCOLOR
-                RESOLUTION (str): RESOLUTION
-                EXCEPTIONS (str): EXCEPTIONS
+                BGCOLOR (str): Background color for the image in hexadecimal format (e.g. '0xFF0000' for red, '0x0000FF' for blue). Requires TRANSPARENT=FALSE to take effect.
+                RESOLUTION (str): Resolution of the map image. Must be >= 72. Values below 72 cause a server error.
+                EXCEPTIONS (str): Format for reporting exceptions. Supported values: 'XML' (default), 'INIMAGE', 'BLANK'.
+                DPI (str): DPI hint (accepted by server but silently ignored — has no effect on output. From WMS POST documentation examples).
+                MAP_RESOLUTION (str): Map resolution hint (accepted by server but silently ignored — has no effect on output. From WMS POST documentation examples).
+                FORMAT_OPTIONS (str): Additional format options e.g. 'dpi:96' (accepted by server but silently ignored — has no effect on output. From WMS POST documentation examples).
+                SLD_BODY (str): Precisely JSON style definition for customizing layer appearance. When provided, the request is sent as POST with SLD_BODY as URL-encoded form data. Use empty string ('') or omit entirely to use default server styles. NOTE: passing SLD_BODY='{}' (JSON empty object string) causes a server-side InvalidStyleDetails error — always use SLD_BODY='' or omit.
 
         Returns:
             Dict[str, Any]: For GetMap success: Dict with keys 'image_base64' (str), 'content_type' (str), 'size_bytes' (int).
@@ -367,7 +270,7 @@ Additional capabilities include:
                 On any error (HTTP 4xx/5xx or WMS ServiceException): Dict with key 'error' (str) containing the error detail or ServiceExceptionReport XML.
 
         Example:
-            wms_get_request(REQUEST="GetCapabilities", SERVICE="WMS", VERSION="1.3.0")
+            wms_request(REQUEST="GetCapabilities", SERVICE="WMS", VERSION="1.3.0")
         """
         try:
             url = f"{self.base_url}/v1/spatial/wms"
@@ -379,14 +282,28 @@ Additional capabilities include:
             kwargs_upper = {k.upper(): v for k, v in kwargs.items()}
             params = {name: kwargs_upper[name] for name in _wms_canonical if name in kwargs_upper}
             request_type = params.get("REQUEST", "").upper()
-            logger.debug(f"[wms_get_request] GET {url}")
-            logger.debug(f"[wms_get_request] Request params: {params}")
-            response = self.session.get(url, params=params, headers={"Accept": "*/*"})
+
+            # Route: SLD_BODY present → POST, otherwise → GET
+            sld_body = kwargs_upper.get("SLD_BODY")
+            if sld_body is not None:
+                form_data = {"SLD_BODY": sld_body}
+                headers = dict(self.session.headers)
+                headers.pop("Content-Type", None)
+                headers["Accept"] = "image/png"
+                headers["Content-Type"] = "application/x-www-form-urlencoded"
+                logger.debug(f"[wms_request] POST {url}")
+                logger.debug(f"[wms_request] Request params: {params}")
+                response = self.session.post(url, params=params, data=form_data, headers=headers)
+            else:
+                logger.debug(f"[wms_request] GET {url}")
+                logger.debug(f"[wms_request] Request params: {params}")
+                response = self.session.get(url, params=params, headers={"Accept": "*/*"})
+
             content_type = response.headers.get("Content-Type", "")
             if "image" in content_type:
-                logger.debug(f"[wms_get_request] Raw response: binary {len(response.content)} bytes, {content_type}")
+                logger.debug(f"[wms_request] Raw response: binary {len(response.content)} bytes, {content_type}")
             else:
-                logger.debug(f"[wms_get_request] Raw response: {response.text}")
+                logger.debug(f"[wms_request] Raw response: {response.text}")
             response.raise_for_status()
             if "image" not in content_type and "<ServiceException" in response.text:
                 raise ValueError(response.text)
@@ -402,87 +319,15 @@ Additional capabilities include:
                 return {"xml": response.text, "content_type": content_type}
             return {"error": f"Unexpected response, content_type: {content_type} Check logs in DEBUG mode for more details"}
         except Exception as e:
-            logger.error(f"WMS get request error: {e}")
-            return self._build_error("WMS get request", e)
-
-    def wms_post_get_map(self, **kwargs) -> Dict[str, Any]:
-        """Processes WMS GetMap requests using a POST method. Accepts SLD_BODY as a form parameter (URL-encoded JSON). WMS service errors (ServiceExceptionReport) with HTTP 2xx are raised as exceptions and returned as {"error": <xml>}.
-
-        Args:
-            **kwargs: Additional keyword arguments passed to the API.
-                REQUEST (str): WMS request type
-                SERVICE (str): Service type
-                VERSION (str): WMS version ('1.3.0' uses crs; '1.1.1' uses srs)
-                crs (str): Coordinate reference system for WMS 1.3.0 (e.g. 'CRS:84', 'EPSG:4326', 'EPSG:3857')
-                srs (str): Spatial reference system for WMS 1.1.1 (e.g. 'EPSG:4326', 'EPSG:3857')
-                BBOX (str): BBOX
-                width (str): width
-                height (str): height
-                layers (str): layers
-                STYLES (str): Comma-separated list of style names, one per requested layer. MUST always be supplied. Omitting STYLES entirely causes a server-side StyleNotDefined error.
-                FORMAT (str): FORMAT
-                TRANSPARENT (str): TRANSPARENT
-                DPI (str): DPI hint (accepted by server but silently ignored — has no effect on output).
-                MAP_RESOLUTION (str): Map resolution hint (accepted by server but silently ignored — has no effect on output).
-                FORMAT_OPTIONS (str): Additional format options e.g. 'dpi:96' (accepted by server but silently ignored — has no effect on output).
-                SLD_BODY (str): URL-encoded JSON style definition. Use empty string ('') or omit entirely to use default server styles. NOTE: passing SLD_BODY='{}' (JSON empty object string) causes a server-side InvalidStyleDetails error — always use SLD_BODY='' or omit.
-
-        Returns:
-            Dict[str, Any]: On success: Dict with keys 'image_base64' (str), 'content_type' (str), 'size_bytes' (int).
-                On any error (HTTP 4xx/5xx or WMS ServiceException): Dict with key 'error' (str) containing the error detail or ServiceExceptionReport XML.
-
-        Example:
-            wms_post_get_map(
-                REQUEST="GetMap",
-                SERVICE="WMS",
-                VERSION="1.3.0",
-                crs="CRS:84",
-                BBOX="-122.712622,38.035008,-122.692382,38.045271",
-                width="640",
-                height="480",
-                layers="wildfire_risk",
-                FORMAT="image/png",
-                STYLES=""
-            )
-        """
-        try:
-            url = f"{self.base_url}/v1/spatial/wms"
-            # Normalize parameter names to uppercase (WMS spec: parameter names are case-insensitive)
-            _wms_post_canonical = ["REQUEST", "SERVICE", "VERSION", "CRS", "SRS", "BBOX", "WIDTH", "HEIGHT",
-                                   "LAYERS", "STYLES", "FORMAT", "TRANSPARENT"]
-            kwargs_upper = {k.upper(): v for k, v in kwargs.items()}
-            params = {name: kwargs_upper[name] for name in _wms_post_canonical if name in kwargs_upper}
-            form_data = {}
-            if "SLD_BODY" in kwargs_upper:
-                form_data["SLD_BODY"] = kwargs_upper["SLD_BODY"]
-            headers = dict(self.session.headers)
-            headers.pop("Content-Type", None)
-            headers["Accept"] = "image/png"
-            headers["Content-Type"] = "application/x-www-form-urlencoded"
-            logger.debug(f"[wms_post_get_map] POST {url}")
-            logger.debug(f"[wms_post_get_map] Request params: {params}")
-            response = self.session.post(url, params=params, data=form_data, headers=headers)
-            content_type = response.headers.get("Content-Type", "")
-            if "image" in content_type:
-                logger.debug(f"[wms_post_get_map] Raw response: binary {len(response.content)} bytes, {content_type}")
-            else:
-                logger.debug(f"[wms_post_get_map] Raw response: {response.text}")
-            response.raise_for_status()
-            if "image" not in content_type and "<ServiceException" in response.text:
-                raise ValueError(response.text)
-            if "image" in content_type:
-                return {"image_base64": base64.b64encode(response.content).decode(), "content_type": content_type, "size_bytes": len(response.content)}
-            return {"error": f"Unexpected response, content_type: {content_type} Check logs in DEBUG mode for more details"}
-        except Exception as e:
-            logger.error(f"WMS POST GetMap error: {e}")
-            return self._build_error("WMS POST GetMap", e)
+            logger.error(f"WMS request error: {e}")
+            return self._build_error("WMS request", e)
 
     # ========================================
     # WMTS (Web Map Tile Service) APIs
     # ========================================
 
     def wmts_request(self, **kwargs) -> Dict[str, Any]:
-        """Use the appropriate parameters based on the request type.
+        """Use the appropriate parameters based on the request type. For GetTile, optionally set profile='simple' to use the RESTful simple profile endpoint (no Style or TileMatrixSet needed) instead of the default KVP endpoint.
 
         Args:
             **kwargs: Additional keyword arguments passed to the API.
@@ -490,12 +335,13 @@ Additional capabilities include:
                 Request (str): Defines the request type. Available values : GetCapabilities, GetTile
                 Version (str): WMTS version.
                 Layer (str): Available layer name via Data or Repository (required for `GetTile`).
-                Style (str): Comma-separated list of one rendering style per requested layer(required for `GetTile`).
-                TileMatrixSet (str): Tile matrix set to generate tiles for(required for `GetTile`).
+                Style (str): Rendering style for layer (required for `GetTile` without profile).
+                TileMatrixSet (str): Tile matrix set to generate tiles for (required for `GetTile` without profile).
                 TileMatrix (str): An integer value which will be number of levels or zoom level(required for `GetTile`).
                 TileRow (int): An integer value that specifies the row number of the tile you want (required for `GetTile`).
                 TileCol (int): An integer value that specifies the column number of the tile you want (required for `GetTile`).
                 Format (str): The format in which the map image is to be returned(required for `GetTile`).
+                profile (str): RESTful tile profile. Use 'simple' for the simple profile endpoint (fewer required params). Omit or leave None for the default KVP endpoint.
 
         Returns:
             Dict[str, Any]: For GetTile: Dict with keys 'image_base64' (str), 'content_type' (str), 'size_bytes' (int).
@@ -505,11 +351,39 @@ Additional capabilities include:
             wmts_request(Service="WMTS", Request="GetCapabilities")
         """
         try:
+            kwargs_upper = {k.upper(): v for k, v in kwargs.items()}
+            request_type = kwargs_upper.get("REQUEST", "").upper()
+            profile = kwargs_upper.get("PROFILE")
+
+            # Simple profile: RESTful URL, no Style/TileMatrixSet needed
+            if request_type == "GETTILE" and profile and profile.lower() == "simple":
+                version = kwargs_upper.get("VERSION", "1.0.0")
+                layer = kwargs_upper.get("LAYER", "")
+                tile_matrix = kwargs_upper.get("TILEMATRIX", "")
+                tile_col = kwargs_upper.get("TILECOL", "")
+                tile_row = kwargs_upper.get("TILEROW", "")
+                fmt = kwargs_upper.get("FORMAT", "png")
+                # Strip leading "image/" if present (e.g. "image/png" -> "png")
+                if "/" in str(fmt):
+                    fmt = str(fmt).split("/")[-1]
+                url = f"{self.base_url}/v1/spatial/wmts/{version}/simpleProfileTile/tiles/{layer}/{tile_matrix}/{tile_col}/{tile_row}.{fmt}"
+                logger.debug(f"[wmts_request] (simple profile) GET {url}")
+                response = self.session.get(url)
+                content_type = response.headers.get("Content-Type", "")
+                if "image/" in content_type.lower() or "application/vnd.mapbox-vector-tile" in content_type.lower():
+                    logger.debug(f"[wmts_request] Raw response: binary {len(response.content)} bytes, {content_type}")
+                else:
+                    logger.debug(f"[wmts_request] Raw response: {response.text}")
+                response.raise_for_status()
+                if "image/" in content_type.lower() or "application/vnd.mapbox-vector-tile" in content_type.lower():
+                    return {"image_base64": base64.b64encode(response.content).decode(), "content_type": content_type, "size_bytes": len(response.content)}
+                return {"error": f"Unexpected response, content_type: {content_type} Check logs in DEBUG mode for more details"}
+
+            # Default: KVP endpoint
             url = f"{self.base_url}/v1/spatial/wmts"
             # Normalize WMTS KVP parameter names (case-insensitive per WMTS spec)
             _wmts_canonical = ["SERVICE", "REQUEST", "VERSION", "LAYER", "STYLE",
                                "TILEMATRIXSET", "TILEMATRIX", "TILEROW", "TILECOL", "FORMAT"]
-            kwargs_upper = {k.upper(): v for k, v in kwargs.items()}
             params = {name: kwargs_upper[name] for name in _wmts_canonical if name in kwargs_upper}
             logger.debug(f"[wmts_request] GET {url}")
             logger.debug(f"[wmts_request] Request params: {params}")
@@ -522,98 +396,9 @@ Additional capabilities include:
             response.raise_for_status()
             if "image/" in content_type.lower() or "application/vnd.mapbox-vector-tile" in content_type.lower():
                 return {"image_base64": base64.b64encode(response.content).decode(), "content_type": content_type, "size_bytes": len(response.content)}
-            if "xml" in content_type.lower() or params.get("REQUEST", "").upper() == "GETCAPABILITIES":
+            if "xml" in content_type.lower() or request_type == "GETCAPABILITIES":
                 return {"xml": response.text, "content_type": content_type or "application/xml"}
             return {"error": f"Unexpected response, content_type: {content_type} Check logs in DEBUG mode for more details"}
         except Exception as e:
             logger.error(f"WMTS request error: {e}")
             return self._build_error("WMTS request", e)
-
-    def wmts_get_standard_tile(self, Version: str, Layer: str, Style: str, TileMatrixSet: str, TileMatrix: str, TileCol: int, TileRow: int, Format: str, **kwargs) -> Dict[str, Any]:
-        """Returns a map tile based on the RESTful encoding for the WMTS service.
-
-
-        Args:
-            Version (str): WMTS version (default is `1.0.0`).
-            Layer (str): Available layer name via Data or Repository.
-            Style (str): Comma-separated list of one rendering style per requested layer.
-            TileMatrixSet (str): Tile matrix set to generate tiles for.
-            TileMatrix (str): Level of detail (zoom level).
-            TileCol (int): An integer value that specifies the column number of the tile you want.
-            TileRow (int): An integer value that specifies the row number of the tile you want.
-            Format (str): Image format extension.
-            **kwargs: Additional keyword arguments passed to the API.
-
-        Returns:
-            Dict[str, Any]: Dict with keys 'image_base64' (str), 'content_type' (str), 'size_bytes' (int).
-
-        Example:
-            wmts_get_standard_tile(
-                Version="1.0.0",
-                Layer="parcels",
-                Style="default",
-                TileMatrixSet="WorldWebMercatorQuad_0_to_19",
-                TileMatrix="17",
-                TileCol=31118,
-                TileRow=50069,
-                Format="png"
-            )
-        """
-        try:
-            url = f"{self.base_url}/v1/spatial/wmts/{Version}/default/tiles/{Layer}/{Style}/{TileMatrixSet}/{TileMatrix}/{TileCol}/{TileRow}.{Format}"
-            logger.debug(f"[wmts_get_standard_tile] GET {url}")
-            response = self.session.get(url)
-            content_type = response.headers.get("Content-Type", "")
-            if "image/" in content_type.lower() or "application/vnd.mapbox-vector-tile" in content_type.lower():
-                logger.debug(f"[wmts_get_standard_tile] Raw response: binary {len(response.content)} bytes, {content_type}")
-            else:
-                logger.debug(f"[wmts_get_standard_tile] Raw response: {response.text}")
-            response.raise_for_status()
-            if "image/" in content_type.lower() or "application/vnd.mapbox-vector-tile" in content_type.lower():
-                return {"image_base64": base64.b64encode(response.content).decode(), "content_type": content_type, "size_bytes": len(response.content)}
-            return {"error": f"Unexpected response, content_type: {content_type} Check logs in DEBUG mode for more details"}
-        except Exception as e:
-            logger.error(f"WMTS get standard tile error: {e}")
-            return self._build_error("WMTS get standard tile", e)
-
-    def wmts_get_simple_tile(self, Version: str, Layer: str, TileMatrix: str, TileCol: int, TileRow: int, Format: str, **kwargs) -> Dict[str, Any]:
-        """Returns a map tile based on the RESTful encoding for the WMTS service.
-
-        Args:
-            Version (str): WMTS version (default is `1.0.0`).
-            Layer (str): Available layer name via Data or Repository.
-            TileMatrix (str): Level of detail (zoom level).
-            TileCol (int): An integer value that specifies the column number of the tile you want.
-            TileRow (int): An integer value that specifies the row number of the tile you want.
-            Format (str): Image format extension.
-            **kwargs: Additional keyword arguments passed to the API.
-
-        Returns:
-            Dict[str, Any]: Dict with keys 'image_base64' (str), 'content_type' (str), 'size_bytes' (int).
-
-        Example:
-            wmts_get_simple_tile(
-                Version="1.0.0",
-                Layer="parcels",
-                TileMatrix="17",
-                TileCol=31118,
-                TileRow=50069,
-                Format="png"
-            )
-        """
-        try:
-            url = f"{self.base_url}/v1/spatial/wmts/{Version}/simpleProfileTile/tiles/{Layer}/{TileMatrix}/{TileCol}/{TileRow}.{Format}"
-            logger.debug(f"[wmts_get_simple_tile] GET {url}")
-            response = self.session.get(url)
-            content_type = response.headers.get("Content-Type", "")
-            if "image/" in content_type.lower() or "application/vnd.mapbox-vector-tile" in content_type.lower():
-                logger.debug(f"[wmts_get_simple_tile] Raw response: binary {len(response.content)} bytes, {content_type}")
-            else:
-                logger.debug(f"[wmts_get_simple_tile] Raw response: {response.text}")
-            response.raise_for_status()
-            if "image/" in content_type.lower() or "application/vnd.mapbox-vector-tile" in content_type.lower():
-                return {"image_base64": base64.b64encode(response.content).decode(), "content_type": content_type, "size_bytes": len(response.content)}
-            return {"error": f"Unexpected response, content_type: {content_type} Check logs in DEBUG mode for more details"}
-        except Exception as e:
-            logger.error(f"WMTS get simple tile error: {e}")
-            return self._build_error("WMTS get simple tile", e)

--- a/dis-locate-apis-v2/precisely/tax_emergency.py
+++ b/dis-locate-apis-v2/precisely/tax_emergency.py
@@ -125,104 +125,64 @@ class TaxEmergencyMixin:
             logger.error(f"Tax jurisdiction lookup error: {e}")
             return self._build_error("Tax jurisdiction lookup", e)
 
-    def psap_address(self, address: Dict, **kwargs) -> Dict[str, Any]:
-        """Retrieve PSAP contact details using address input
+    def find_emergency_services(
+        self,
+        address: Dict = None,
+        location: Dict = None,
+        fcc_id: str = None,
+        include_ahj: bool = True,
+        **kwargs,
+    ) -> Dict[str, Any]:
+        """Find the PSAP (911 dispatch center) and optionally the AHJ (Authority Having Jurisdiction)
+        for a US address, coordinate, or FCC ID.
 
-        Required address structure:
-        {
-            "addressLines": ["860 White Plains Road Trumbull CT 06611, USA"],
-            "admin1": "Connecticut",
-            "admin2": "Trumbull",
-            "city": "Trumbull",
-            "postalCode": "06611"
-        }
+        Provide exactly one of address, location, or fcc_id.
+
+        Args:
+            address: Structured US address with addressLines, city, admin1, postalCode.
+            location: Geographic coordinates as {"coordinates": [longitude, latitude]}.
+            fcc_id: FCC-assigned PSAP identifier (e.g., '1404').
+            include_ahj: When True (default), returns both PSAP and AHJ data.
+                When False, returns only PSAP data. Ignored when fcc_id is used
+                (FCC ID lookup always includes AHJ).
         """
+        inputs = sum(x is not None for x in (address, location, fcc_id))
+        if inputs != 1:
+            return {
+                "error": {
+                    "message": (
+                        "Provide exactly one of 'address', 'location', or 'fcc_id'. "
+                        f"Received {inputs} inputs."
+                    ),
+                    "error_type": "ValidationError",
+                }
+            }
+
         try:
-            url = f"{self.base_url}/v1/emergency-info/psap/address"
-            json_data = {"address": address}
-            logger.debug(f"[psap_address] Request payload: {json.dumps(json_data, indent=2)}")
-            response = self.session.post(url, json=json_data)
-            logger.debug(f"[psap_address] Raw response: {response.text}")
+            if fcc_id is not None:
+                url = f"{self.base_url}/v1/emergency-info/psap-ahj/fccid"
+                params = {"fccId": fcc_id}
+                logger.debug(f"[find_emergency_services] GET {url}")
+                logger.debug(f"[find_emergency_services] Request params: {params}")
+                response = self.session.get(url, params=params)
+            elif address is not None:
+                segment = "psap-ahj" if include_ahj else "psap"
+                url = f"{self.base_url}/v1/emergency-info/{segment}/address"
+                json_data = {"address": address}
+                logger.debug(f"[find_emergency_services] POST {url}")
+                logger.debug(f"[find_emergency_services] Request payload: {json.dumps(json_data, indent=2)}")
+                response = self.session.post(url, json=json_data)
+            else:  # location
+                segment = "psap-ahj" if include_ahj else "psap"
+                url = f"{self.base_url}/v1/emergency-info/{segment}/location"
+                json_data = {"location": location}
+                logger.debug(f"[find_emergency_services] POST {url}")
+                logger.debug(f"[find_emergency_services] Request payload: {json.dumps(json_data, indent=2)}")
+                response = self.session.post(url, json=json_data)
+
+            logger.debug(f"[find_emergency_services] Raw response: {response.text}")
             response.raise_for_status()
             return response.json()
         except Exception as e:
-            logger.error(f"PSAP address error: {e}")
-            return self._build_error("PSAP address", e)
-
-    def psap_location(self, location: Dict, **kwargs) -> Dict[str, Any]:
-        """Retrieve PSAP contact details using location input
-
-        Required location structure:
-        {
-            "coordinates": [-73.22344, 41.23443]  # [longitude, latitude]
-        }
-        """
-        try:
-            url = f"{self.base_url}/v1/emergency-info/psap/location"
-            json_data = {"location": location}
-            logger.debug(f"[psap_location] Request payload: {json.dumps(json_data, indent=2)}")
-            response = self.session.post(url, json=json_data)
-            logger.debug(f"[psap_location] Raw response: {response.text}")
-            response.raise_for_status()
-            return response.json()
-        except Exception as e:
-            logger.error(f"PSAP location error: {e}")
-            return self._build_error("PSAP location", e)
-
-    def psap_ahj_address(self, address: Dict, **kwargs) -> Dict[str, Any]:
-        """Retrieve PSAP+AHJ contact details using address input
-
-        Required address structure:
-        {
-            "addressLines": ["860 White Plains Road Trumbull CT 06611, USA"],
-            "admin1": "Connecticut",
-            "admin2": "Trumbull",
-            "city": "Trumbull",
-            "postalCode": "06611"
-        }
-        """
-        try:
-            url = f"{self.base_url}/v1/emergency-info/psap-ahj/address"
-            json_data = {"address": address}
-            logger.debug(f"[psap_ahj_address] Request payload: {json.dumps(json_data, indent=2)}")
-            response = self.session.post(url, json=json_data)
-            logger.debug(f"[psap_ahj_address] Raw response: {response.text}")
-            response.raise_for_status()
-            return response.json()
-        except Exception as e:
-            logger.error(f"PSAP AHJ address error: {e}")
-            return self._build_error("PSAP AHJ address", e)
-
-    def psap_ahj_location(self, location: Dict, **kwargs) -> Dict[str, Any]:
-        """Retrieve PSAP+AHJ contact details using location input
-
-        Required location structure:
-        {
-            "coordinates": [-73.22344, 41.23443]  # [longitude, latitude]
-        }
-        """
-        try:
-            url = f"{self.base_url}/v1/emergency-info/psap-ahj/location"
-            json_data = {"location": location}
-            logger.debug(f"[psap_ahj_location] Request payload: {json.dumps(json_data, indent=2)}")
-            response = self.session.post(url, json=json_data)
-            logger.debug(f"[psap_ahj_location] Raw response: {response.text}")
-            response.raise_for_status()
-            return response.json()
-        except Exception as e:
-            logger.error(f"PSAP AHJ location error: {e}")
-            return self._build_error("PSAP AHJ location", e)
-
-    def psap_ahj_fccid(self, fcc_id: str, **kwargs) -> Dict[str, Any]:
-        """Retrieve PSAP+AHJ contact details using FCC ID"""
-        try:
-            url = f"{self.base_url}/v1/emergency-info/psap-ahj/fccid"
-            params = {"fccId": fcc_id}
-            logger.debug(f"[psap_ahj_fccid] Request params: {params}")
-            response = self.session.get(url, params=params)
-            logger.debug(f"[psap_ahj_fccid] Raw response: {response.text}")
-            response.raise_for_status()
-            return response.json()
-        except Exception as e:
-            logger.error(f"PSAP AHJ FCC ID error: {e}")
-            return self._build_error("PSAP AHJ FCC ID", e)
+            logger.error(f"Emergency services lookup error: {e}")
+            return self._build_error("Emergency services lookup", e)

--- a/dis-locate-apis-v2/precisely/timezone.py
+++ b/dis-locate-apis-v2/precisely/timezone.py
@@ -2,36 +2,48 @@
 
 import json
 import logging
-from typing import Any, Dict
+from typing import Any, Dict, List
 
 logger = logging.getLogger(__name__)
 
 
 class TimezoneMixin:
-    def timezone_addresses(self, data: Dict, **kwargs) -> Dict[str, Any]:
-        """Get timezone for addresses"""
-        try:
-            url = f"{self.base_url}/v1/timezone/address"
-            json_data = data
-            logger.debug(f"[timezone_addresses] Request payload: {json.dumps(json_data, indent=2)}")
-            response = self.session.post(url, json=json_data)
-            logger.debug(f"[timezone_addresses] Raw response: {response.text}")
-            response.raise_for_status()
-            return response.json()
-        except Exception as e:
-            logger.error(f"Timezone addresses error: {e}")
-            return self._build_error("Timezone addresses", e)
+    def get_timezones(self, addresses: List[Dict] = None, locations: List[Dict] = None, **kwargs) -> Dict[str, Any]:
+        """Look up timezones by addresses or geographic coordinates.
 
-    def timezone_locations(self, data: Dict, **kwargs) -> Dict[str, Any]:
-        """Get timezone for locations"""
+        Accepts either an addresses array or a locations array (not both).
+        Routes to the correct API endpoint based on which input is provided.
+
+        Args:
+            addresses: List of address objects with timestamp and address
+                (addressLines, country, optional id). Uses /v1/timezone/address.
+            locations: List of location objects with id, timestamp, and geometry
+                (coordinates as [lon, lat]). Uses /v1/timezone/location.
+        """
         try:
-            url = f"{self.base_url}/v1/timezone/location"
-            json_data = data
-            logger.debug(f"[timezone_locations] Request payload: {json.dumps(json_data, indent=2)}")
+            if addresses and locations:
+                return self._build_error(
+                    "Get timezones",
+                    ValueError("Provide either 'addresses' or 'locations', not both."),
+                )
+
+            if addresses:
+                url = f"{self.base_url}/v1/timezone/address"
+                json_data = {"addresses": addresses}
+            elif locations:
+                url = f"{self.base_url}/v1/timezone/location"
+                json_data = {"locations": locations}
+            else:
+                return self._build_error(
+                    "Get timezones",
+                    ValueError("Provide either 'addresses' or 'locations'."),
+                )
+
+            logger.debug(f"[get_timezones] Request payload: {json.dumps(json_data, indent=2)}")
             response = self.session.post(url, json=json_data)
-            logger.debug(f"[timezone_locations] Raw response: {response.text}")
+            logger.debug(f"[get_timezones] Raw response: {response.text}")
             response.raise_for_status()
             return response.json()
         except Exception as e:
-            logger.error(f"Timezone locations error: {e}")
-            return self._build_error("Timezone locations", e)
+            logger.error(f"Get timezones error: {e}")
+            return self._build_error("Get timezones", e)

--- a/dis-locate-apis-v2/precisely/verification.py
+++ b/dis-locate-apis-v2/precisely/verification.py
@@ -8,50 +8,64 @@ logger = logging.getLogger(__name__)
 
 
 class VerificationMixin:
-    def verify_email(self, email: str, **kwargs) -> Dict[str, Any]:
-        """Verify a single email address"""
+    def verify_emails(self, emails, **kwargs) -> Dict[str, Any]:
+        """Verify one or more email addresses for deliverability, validity, and format.
+
+        Accepts a single email string or a list of emails (strings or objects).
+        Always uses the batch endpoint; a single string is auto-wrapped.
+
+        Args:
+            emails: A single email string (e.g., "john@company.com"),
+                a list of email strings, or a list of dicts with 'email'
+                (and optional 'id') keys.  Maximum 10 emails per call.
+        """
         try:
-            url = f"{self.base_url}/v1/emails/verify"
-            json_data = {"email": email}
-            logger.debug(f"[verify_email] Request payload: {json.dumps(json_data, indent=2)}")
+            url = f"{self.base_url}/v1/emails/verify/batch"
+
+            # Normalize input → list of {"email": ...} dicts
+            if isinstance(emails, str):
+                processed_emails = [{"email": emails}]
+            elif isinstance(emails, list):
+                processed_emails = []
+                for entry in emails:
+                    if isinstance(entry, str):
+                        processed_emails.append({"email": entry})
+                    elif isinstance(entry, dict):
+                        if "email" in entry:
+                            processed_emails.append(entry)
+                        else:
+                            email_value = None
+                            for key, value in entry.items():
+                                if "email" in key.lower() or "@" in str(value):
+                                    email_value = value
+                                    break
+                            if email_value:
+                                processed_emails.append({"email": email_value})
+                            else:
+                                logger.warning(f"Could not extract email from object: {entry}")
+                    else:
+                        logger.warning(f"Skipping unsupported email entry type: {type(entry)}")
+            else:
+                return self._build_error(
+                    "Email verification",
+                    ValueError("'emails' must be a string or a list of email strings/objects."),
+                )
+
+            if not processed_emails:
+                return self._build_error(
+                    "Email verification",
+                    ValueError("No valid email addresses provided."),
+                )
+
+            json_data = {"emails": processed_emails}
+            logger.debug(f"[verify_emails] Request payload: {json.dumps(json_data, indent=2)}")
             response = self.session.post(url, json=json_data)
-            logger.debug(f"[verify_email] Raw response: {response.text}")
+            logger.debug(f"[verify_emails] Raw response: {response.text}")
             response.raise_for_status()
             return response.json()
         except Exception as e:
             logger.error(f"Email verification error: {e}")
             return self._build_error("Email verification", e)
-
-    def verify_batch_emails(self, emails: List, **kwargs) -> Dict[str, Any]:
-        """Verify a batch of email addresses - accepts either strings or objects"""
-        try:
-            url = f"{self.base_url}/v1/emails/verify/batch"
-            processed_emails = []
-            for email in emails:
-                if isinstance(email, str):
-                    processed_emails.append({"email": email})
-                elif isinstance(email, dict):
-                    if "email" in email:
-                        processed_emails.append(email)
-                    else:
-                        email_value = None
-                        for key, value in email.items():
-                            if "email" in key.lower() or "@" in str(value):
-                                email_value = value
-                                break
-                        if email_value:
-                            processed_emails.append({"email": email_value})
-                        else:
-                            logger.warning(f"Could not extract email from object: {email}")
-            json_data = {"emails": processed_emails}
-            logger.debug(f"[verify_batch_emails] Request payload: {json.dumps(json_data, indent=2)}")
-            response = self.session.post(url, json=json_data)
-            logger.debug(f"[verify_batch_emails] Raw response: {response.text}")
-            response.raise_for_status()
-            return response.json()
-        except Exception as e:
-            logger.error(f"Batch email verification error: {e}")
-            return self._build_error("Batch email verification", e)
 
     def parse_name(self, data: Dict, **kwargs) -> Dict[str, Any]:
         """Parse a name"""
@@ -67,30 +81,46 @@ class VerificationMixin:
             logger.error(f"Name parsing error: {e}")
             return self._build_error("Name parsing", e)
 
-    def validate_phone(self, data: Dict, **kwargs) -> Dict[str, Any]:
-        """Validate a phone number"""
+    def validate_phones(self, phones, **kwargs) -> Dict[str, Any]:
+        """Validate one or more phone numbers for format, country, and line type.
+
+        Accepts a single phone object or a list of phone objects.
+        Always uses the batch endpoint; a single object is auto-wrapped.
+
+        Args:
+            phones: A dict with 'phoneNumber' (and optional 'country', 'id') for
+                a single phone, or a list of such dicts. Maximum 10 per call.
+        """
         try:
-            url = f"{self.base_url}/v1/phone-numbers/validate"
-            json_data = data
-            logger.debug(f"[validate_phone] Request payload: {json.dumps(json_data, indent=2)}")
+            url = f"{self.base_url}/v1/phone-numbers/validate/batch"
+
+            # Normalize input → list of phone dicts
+            if isinstance(phones, dict) and "phoneNumber" in phones:
+                # Single phone object
+                processed_phones = [phones]
+            elif isinstance(phones, list):
+                processed_phones = phones
+            else:
+                return self._build_error(
+                    "Phone validation",
+                    ValueError(
+                        "'phones' must be a dict with 'phoneNumber' key "
+                        "or a list of such dicts."
+                    ),
+                )
+
+            if not processed_phones:
+                return self._build_error(
+                    "Phone validation",
+                    ValueError("No phone numbers provided."),
+                )
+
+            json_data = {"phoneNumbers": processed_phones}
+            logger.debug(f"[validate_phones] Request payload: {json.dumps(json_data, indent=2)}")
             response = self.session.post(url, json=json_data)
-            logger.debug(f"[validate_phone] Raw response: {response.text}")
+            logger.debug(f"[validate_phones] Raw response: {response.text}")
             response.raise_for_status()
             return response.json()
         except Exception as e:
             logger.error(f"Phone validation error: {e}")
             return self._build_error("Phone validation", e)
-
-    def validate_batch_phones(self, data: Dict, **kwargs) -> Dict[str, Any]:
-        """Validate a batch of phone numbers"""
-        try:
-            url = f"{self.base_url}/v1/phone-numbers/validate/batch"
-            json_data = data
-            logger.debug(f"[validate_batch_phones] Request payload: {json.dumps(json_data, indent=2)}")
-            response = self.session.post(url, json=json_data)
-            logger.debug(f"[validate_batch_phones] Raw response: {response.text}")
-            response.raise_for_status()
-            return response.json()
-        except Exception as e:
-            logger.error(f"Batch phone validation error: {e}")
-            return self._build_error("Batch phone validation", e)

--- a/dis-locate-apis-v2/readme.md
+++ b/dis-locate-apis-v2/readme.md
@@ -1,6 +1,6 @@
-﻿# Precisely MCP Server
+# Precisely MCP Server
 
-A Model Context Protocol (MCP) server that exposes 68 Precisely location intelligence APIs to AI assistants like Claude Desktop, VS Code, Cursor, LangChain, LlamaIndex, and custom applications.
+A Model Context Protocol (MCP) server that exposes 57 Precisely location intelligence APIs to AI assistants like Claude Desktop, VS Code, Cursor, LangChain, LlamaIndex, and custom applications.
 
 ## Features
 
@@ -167,7 +167,7 @@ async def test_http():
         async with ClientSession(read, write) as session:
             await session.initialize()
             
-            # List all 68 tools
+            # List all 51 tools
             tools = await session.list_tools()
             print(f"Available tools: {len(tools.tools)}")
             
@@ -192,7 +192,7 @@ async def test_http():
         async with ClientSession(read, write) as session:
             await session.initialize()
             
-            # List all 68 tools
+            # List all 51 tools
             tools = await session.list_tools()
             print(f"Available tools: {len(tools.tools)}")
             
@@ -223,7 +223,7 @@ async def use_with_langchain():
         }
     })
     
-    # Get all 68 tools as LangChain tools
+    # Get all 51 tools as LangChain tools
     tools = await client.get_tools()
     print(f"LangChain tools: {len(tools)} tools available")
     
@@ -299,13 +299,13 @@ python test_precisely_mcp.py
 Test Architecture:
 
 1. **Layer 1 - API Core**: Validates initialization and core functionality
-2. **Layer 2 - MCP Server**: Verifies all 68 tools are properly defined
+2. **Layer 2 - MCP Server**: Verifies all 51 tools are properly defined
 3. **Layer 3 - Functional**: Tests all 72 test cases with real API calls
 
 Test Features:
 
 - Single unified test file
-- 100% coverage (68/68 tools)
+- 100% coverage (51/51 tools)
 - Comprehensive logging (query, payload, response)
 - Detailed test reports in test_logs/
 - JSON results for CI/CD integration
@@ -323,120 +323,103 @@ Failed:    0
 Pass Rate: 100.0%
 ```
 
-## Available APIs (68 Tools)
+## Available APIs (51 Tools)
 
-### Geocoding & Address (9 tools)
+### Geocoding & Address (6 tools)
 
 1. geocode - Convert address to coordinates
 2. reverse_geocode - Convert coordinates to address
 3. verify_address - Verify and standardize addresses
-4. autocomplete - Address autocomplete suggestions
-5. autocomplete_postal_city - Postal code and city autocomplete
-6. autocomplete_v2 - Express autocomplete (V2)
-7. lookup - Lookup address by PreciselyID
-8. parse_address - Parse single address into components
-9. parse_address_batch - Parse multiple addresses
+4. autocomplete_address - Address, postal code, and city autocomplete (standard or express)
+5. lookup - Lookup address by PreciselyID
+6. parse_addresses - Parse addresses into components (single or batch, max 10)
 
 ### Property Information (7 tools)
 
-10. get_property_data - Detailed property information
-11. get_property_attributes_by_address - Property attributes
-12. get_replacement_cost_by_address - Property replacement cost estimates
-13. get_buildings_by_address - Building information
-14. get_parcels_by_address - Parcel/lot information
-15. get_neighborhoods_by_address - Neighborhood details
-16. get_schools_by_address - Nearby schools information
+7. get_property_data - Detailed property information
+8. get_property_attributes_by_address - Property attributes
+9. get_replacement_cost_by_address - Property replacement cost estimates
+10. get_buildings_by_address - Building information
+11. get_parcels_by_address - Parcel/lot information
+12. get_neighborhoods_by_address - Neighborhood details
+13. get_schools_by_address - Nearby schools information
 
 ### Risk Assessment (6 tools)
 
-17. get_flood_risk_by_address - Flood zone and risk assessment
-18. get_wildfire_risk_by_address - Wildfire risk analysis
-19. get_earth_risk - Earthquake risk assessment
-20. get_coastal_risk - Coastal hazard analysis
-21. get_property_fire_risk - Fire risk assessment
-22. get_historical_weather_risk - Historical weather patterns
+14. get_flood_risk_by_address - Flood zone and risk assessment
+15. get_wildfire_risk_by_address - Wildfire risk analysis
+16. get_earth_risk - Earthquake risk assessment
+17. get_coastal_risk - Coastal hazard analysis
+18. get_property_fire_risk - Fire risk assessment
+19. get_historical_weather_risk - Historical weather patterns
 
 ### Demographics & Safety (4 tools)
 
-23. get_demographics - Population and demographic data
-24. get_crime_index - Crime statistics and safety index
-25. get_psyte_geodemographics_by_address - Lifestyle segmentation
-26. get_ground_view_by_address - Census block-level demographics
+20. get_demographics - Population and demographic data
+21. get_crime_index - Crime statistics and safety index
+22. get_psyte_geodemographics_by_address - Lifestyle segmentation
+23. get_ground_view_by_address - Census block-level demographics
 
-### Tax & Jurisdiction (10 tools)
+### Tax & Jurisdiction (6 tools)
 
-27. lookup_by_address - Tax jurisdiction by address
-28. lookup_by_location - Tax jurisdiction by coordinates
-29. lookup_by_addresses - Batch tax jurisdiction lookup (addresses)
-30. lookup_by_locations - Batch tax jurisdiction lookup (coordinates)
-31. psap_address - Emergency services (911/PSAP) by address
-32. psap_location - Emergency services by coordinates
-33. psap_ahj_fccid - PSAP info by FCC ID
-34. psap_ahj_address - Authority Having Jurisdiction by address
-35. psap_ahj_location - Authority Having Jurisdiction by coordinates
-36. geo_locate_ip_address - Geolocation by IP address
+24. lookup_by_address - Tax jurisdiction by address
+25. lookup_by_location - Tax jurisdiction by coordinates
+26. lookup_by_addresses - Batch tax jurisdiction lookup (addresses)
+27. lookup_by_locations - Batch tax jurisdiction lookup (coordinates)
+28. find_emergency_services - Emergency services (911/PSAP) and Authority Having Jurisdiction lookup by address, coordinates, or FCC ID
+29. geo_locate_ip_address - Geolocation by IP address
 
-### Validation & Verification (3 tools)
+### Validation & Verification (2 tools)
 
-37. verify_email - Email address verification
-38. verify_batch_emails - Batch email verification
-39. parse_name - Name parsing into components
+30. verify_emails - Email address verification (single or batch, max 10)
+31. parse_name - Name parsing into components
 
-### Phone Services (2 tools)
+### Phone Services (1 tool)
 
-40. validate_phone - Phone number validation
-41. validate_batch_phones - Batch phone validation
+32. validate_phones - Phone number validation (single or batch, max 10)
 
 ### Geolocation (1 tool)
 
-42. geo_locate_wifi_access_point - WiFi access point geolocation
+33. geo_locate_wifi_access_point - WiFi access point geolocation
 
-### Timezone (2 tools)
+### Timezone (1 tool)
 
-43. timezone_addresses - Get timezone for addresses
-44. timezone_locations - Get timezone for coordinates
+34. get_timezones - Get timezone for addresses or coordinates
 
 ### GraphQL Advanced Queries (5 tools)
 
-45. get_addresses_detailed - Comprehensive address details via GraphQL
-46. get_parcel_by_owner_detailed - Parcel ownership queries via GraphQL
-47. get_address_family - Related addresses via GraphQL
-48. get_serviceability - Broadband/utility serviceability via GraphQL
-49. get_places_by_address - Places/points of interest by address via GraphQL
+35. get_addresses_detailed - Comprehensive address details via GraphQL
+36. get_parcel_by_owner_detailed - Parcel ownership queries via GraphQL
+37. get_address_family - Related addresses via GraphQL
+38. get_serviceability - Broadband/utility serviceability via GraphQL
+39. get_places_by_address - Places/points of interest by address via GraphQL
 
 ### Spatial Analysis (7 tools)
 
-50. find_nearest_candidates - Find nearest spatial features by distance
-51. search_at_location - Search for features at/near a location
-52. overlap - Identify spatial overlaps between geometries
-53. get_spatial_products - Get available spatial data product metadata
-54. list_spatial_tables - List available spatial tables
-55. get_table_metadata - Get metadata for a specific spatial table
-56. summarize - Aggregate spatial data within a defined area
+40. find_nearest_candidates - Find nearest spatial features by distance
+41. search_at_location - Search for features at/near a location
+42. overlap - Identify spatial overlaps between geometries
+43. get_spatial_products - Get available spatial data product metadata
+44. list_spatial_tables - List available spatial tables
+45. get_table_metadata - Get metadata for a specific spatial table
+46. summarize - Aggregate spatial data within a defined area
 
-### OGC API Features (10 tools)
+### OGC API Features (6 tools)
 
-57. ogc_landing_page - OGC API landing page with links
-58. ogc_api_definition - Complete OpenAPI definition
-59. ogc_functions - Available spatial functions
-60. ogc_conformance - OGC conformance declaration
-61. ogc_collections - List feature collections
-62. ogc_collection - Information about a specific collection
-63. ogc_collection_schema - Schema for a collection
-64. ogc_collection_queryables - Queryable attributes for a collection
-65. ogc_collection_items - Data records from a collection
-66. ogc_feature_by_id - Get a specific feature by ID
+47. ogc_functions - Available spatial functions
+48. ogc_collections - List feature collections
+49. ogc_collection - Information about a specific collection
+50. ogc_collection_schema - Schema for a collection
+51. ogc_collection_queryables - Queryable attributes for a collection
+52. ogc_collection_items - Data records from a collection, or a single feature by ID
 
-### WMS - Web Map Service (2 tools, 3 tests)
+### WMS - Web Map Service (1 tool, 3 tests)
 
-67. wms_get_request - WMS GET handler (GetCapabilities/GetMap/GetFeatureInfo) — tested with both GetCapabilities and GetFeatureInfo (2 tests)
-68. wms_post_get_map - WMS POST GetMap with custom SLD styling
+53. wms_request - WMS handler (GetCapabilities/GetMap/GetFeatureInfo via GET; GetMap with SLD styling via POST) — tested with GetCapabilities, GetFeatureInfo, and POST GetMap (3 tests)
 
-### WMTS - Web Map Tile Service (3 tools)
+### WMTS - Web Map Tile Service (1 tool, 3 tests)
 
-69. wmts_request - WMTS KVP handler (GetCapabilities/GetTile)
-70. wmts_get_standard_tile - WMTS tile via RESTful standard profile
-71. wmts_get_simple_tile - WMTS tile via RESTful simple profile
+54. wmts_request - WMTS handler (GetCapabilities/GetTile KVP/GetTile simple profile)
 
 ## Project Structure
 
@@ -447,7 +430,7 @@ Pass Rate: 100.0%
  .env.template                      # Credential configuration template
  readme.md                          # This file
  mcp_servers/
-    precisely_wrapper_server.py   # MCP server wrapper (1,300+ lines, 68 tools, dual transport)
+    precisely_wrapper_server.py   # MCP server wrapper (1,300+ lines, 51 tools, dual transport)
     setup_claude_desktop.ps1      # Windows setup script (UTF-8 no-BOM)
  logs/                              # Application logs (automatically generated)
  test_logs/                         # Test results and reports (automatically generated)
@@ -471,7 +454,7 @@ Pass Rate: 100.0%
 
 ### Architecture Changes
 
-- 72 API methods, 68 MCP tools, 72 functional test cases
+- 59 API methods, 51 MCP tools, 72 functional test cases
 - File size reductions: precisely_api_core.py 8% smaller
 - Removed redundant files
 
@@ -479,7 +462,7 @@ Pass Rate: 100.0%
 
 - Fixed UTF-8 BOM issue in setup_claude_desktop.ps1
 - Standardized credential naming
-- Updated test suite for 68 tools
+- Updated test suite for 51 tools
 
 ## Configuration
 

--- a/dis-locate-apis-v2/test_precisely_mcp.py
+++ b/dis-locate-apis-v2/test_precisely_mcp.py
@@ -122,17 +122,17 @@ class PreciselyMCPTestSuite:
         methods = [m for m in dir(self.api) if not m.startswith('_') and callable(getattr(self.api, m))]
         logger.info(f"  Found {len(methods)} API methods")
         
-        if len(methods) != 73:
-            logger.warning(f"  [WARN] Expected 73 methods, found {len(methods)}")
+        if len(methods) != 56:
+            logger.warning(f"  [WARN] Expected 56 methods, found {len(methods)}")
         else:
-            logger.info("  [PASS] All 73 API methods present")
+            logger.info("  [PASS] All 56 API methods present")
         
         # Test 3: Quick smoke tests
         logger.info("\n[3/3] Running Quick Smoke Tests...")
         sample_tests = [
             ("geocode", lambda: self.api.geocode(address="1600 Pennsylvania Ave NW, Washington DC", country="USA")),
             ("verify_address", lambda: self.api.verify_address(address="1600 Pennsylvania Ave NW, Washington DC", country="USA")),
-            ("verify_email", lambda: self.api.verify_email(email="test@example.com")),
+            ("verify_emails", lambda: self.api.verify_emails(emails="test@example.com")),
         ]
         
         passed = 0
@@ -179,10 +179,10 @@ class PreciselyMCPTestSuite:
                 logger.error(f"  [FAIL] Duplicate tools found: {set(duplicates)}")
                 return False
             
-            if len(tools) != 68:
-                logger.warning(f"  [WARN] Expected 68 tools, found {len(tools)}")
+            if len(tools) != 51:
+                logger.warning(f"  [WARN] Expected 51 tools, found {len(tools)}")
             else:
-                logger.info("  [PASS] All 68 MCP tools defined")
+                logger.info("  [PASS] All 51 MCP tools defined")
             
         except Exception as e:
             logger.error(f"  [FAIL] Failed to load MCP server: {e}")
@@ -410,24 +410,24 @@ class PreciselyMCPTestSuite:
             ("Parse Name", "parse_name", "Parse the name John Robert Smith into components",
              {"data": {"name": "John Robert Smith"}}),
             
-            ("Validate Phone Number", "validate_phone", "Is 4144654885 a valid phone number in the US?",
-             {"data": {"phoneNumber": "4144654885", "country": "US"}}),
+            ("Validate Single Phone", "validate_phones", "Is 4144654885 a valid phone number in the US?",
+             {"phones": {"phoneNumber": "4144654885", "country": "US"}}),
             
-            ("Validate Batch Phones", "validate_batch_phones", "Validate multiple phone numbers: 3035551234, 7205559999",
-             {"data": {"phoneNumbers": [{"id": "1", "phoneNumber": "3035551234", "country": "US"}, {"id": "2", "phoneNumber": "7205559999", "country": "US"}]}}),
+            ("Validate Batch Phones", "validate_phones", "Validate multiple phone numbers: 3035551234, 7205559999",
+             {"phones": [{"id": "1", "phoneNumber": "3035551234", "country": "US"}, {"id": "2", "phoneNumber": "7205559999", "country": "US"}]}),
             
-            ("Verify Email", "verify_email", "Is john.doe@company.com a valid email?",
-             {"email": "john.doe@company.com"}),
+            ("Verify Single Email", "verify_emails", "Is john.doe@company.com a valid email?",
+             {"emails": "john.doe@company.com"}),
             
-            ("Verify Batch Emails", "verify_batch_emails", "Verify multiple emails: john@company.com, jane@company.com",
+            ("Verify Batch Emails", "verify_emails", "Verify multiple emails: john@company.com, jane@company.com",
              {"emails": [{"id": "1", "email": "john@company.com"}, {"id": "2", "email": "jane@company.com"}]}),
             
             # Timezone
-            ("Timezone by Address", "timezone_addresses", "What is the timezone for 1700 District Ave, Burlington, MA?",
-             {"data": {"addresses": [{"timestamp": 1691138974831, "address": {"id": "1", "addressLines": ["1700 District Ave, Burlington, MA"], "country": "USA"}}]}}),
+            ("Timezone by Address", "get_timezones", "What is the timezone for 1700 District Ave, Burlington, MA?",
+             {"addresses": [{"timestamp": 1691138974831, "address": {"id": "1", "addressLines": ["1700 District Ave, Burlington, MA"], "country": "USA"}}]}),
             
-            ("Timezone by Location", "timezone_locations", "What is the timezone for coordinates -71.0589, 42.3601?",
-             {"data": {"locations": [{"id": "1", "timestamp": 1691138974831, "geometry": {"coordinates": [-71.0589, 42.3601]}}]}}),
+            ("Timezone by Location", "get_timezones", "What is the timezone for coordinates -71.0589, 42.3601?",
+             {"locations": [{"id": "1", "timestamp": 1691138974831, "geometry": {"coordinates": [-71.0589, 42.3601]}}]}),
             
             # Geocoding & Address Services
             ("Geocode Address", "geocode", "What are the coordinates of 42 Valley Of The Sun Dr, Fairplay, CO 80440?",
@@ -439,20 +439,20 @@ class PreciselyMCPTestSuite:
             ("Verify Address", "verify_address", "Is 1600 Pennsylvania Ave, Washington DC a valid address?",
              {"address": "1600 Pennsylvania Ave, Washington DC", "country": "USA"}),
             
-            ("Parse Address", "parse_address", "Parse 1700 District Ave #300, Burlington, MA 01803 into components",
-             {"address": "1700 District Ave #300, Burlington, MA 01803"}),
+            ("Parse Single Address", "parse_addresses", "Parse 1700 District Ave #300, Burlington, MA 01803 into components",
+             {"addresses": "1700 District Ave #300, Burlington, MA 01803"}),
             
-            ("Parse Address Batch", "parse_address_batch", "Parse multiple addresses: 123 Main St Boston MA, 456 Oak Ave Denver CO",
+            ("Parse Address Batch", "parse_addresses", "Parse multiple addresses: 123 Main St Boston MA, 456 Oak Ave Denver CO",
              {"addresses": [{"id": "1", "address": "123 Main St, Boston, MA 02101"}, {"id": "2", "address": "456 Oak Ave, Denver, CO 80203"}]}),
             
-            ("Autocomplete Address", "autocomplete", "Autocomplete address starting with 1700 District",
+            ("Autocomplete Street", "autocomplete_address", "Autocomplete address starting with 1700 District",
              {"address": {"addressLines": ["1700 District"], "country": "USA"}, "preferences": {"maxResults": 5}}),
             
-            ("Autocomplete Postal City", "autocomplete_postal_city", "Autocomplete postal code 12180 in the USA",
+            ("Autocomplete Postal City", "autocomplete_address", "Autocomplete postal code 12180 in the USA",
              {"address": {"type": "POSTAL", "postAddress": "12180", "country": "USA"}, "preferences": {"maxResults": 5}}),
             
-            ("Autocomplete V2", "autocomplete_v2", "Give me express autocomplete suggestions for 350 Jordan Street, USA",
-             {"address": {"addressLines": ["350 Jordan"], "country": "USA"}, "preferences": {"maxResults": 5}}),
+            ("Autocomplete Express", "autocomplete_address", "Give me express autocomplete suggestions for 350 Jordan Street, USA",
+             {"address": {"addressLines": ["350 Jordan"], "country": "USA"}, "express": True, "preferences": {"maxResults": 5}}),
             
             ("Lookup by PreciselyID", "lookup", "Lookup address for PreciselyID P0000GL41OME",
              {"keys": [{"key": "P0000GL41OME", "country": "USA", "type": "PB_KEY"}]}),
@@ -476,21 +476,21 @@ class PreciselyMCPTestSuite:
             ("Geolocate WiFi Access Point", "geo_locate_wifi_access_point", "Geolocate WiFi access point with MAC address 00:22:75:10:d5:91",
              {"wifi_data": {"servingCell": {"mac": "00:22:75:10:d5:91", "rssi": "-90"}}}),
             
-            # Emergency Services (PSAP)
-            ("PSAP by Address", "psap_address", "What is the 911 service for 860 White Plains Road Trumbull CT 06611?",
+            # Emergency Services (consolidated find_emergency_services)
+            ("Emergency Services by Address (PSAP only)", "find_emergency_services", "What is the 911 service for 860 White Plains Road Trumbull CT 06611?",
+             {"address": {"addressLines": ["860 White Plains Road"], "city": "Trumbull", "admin1": "CT", "postalCode": "06611"}, "include_ahj": False}),
+            
+            ("Emergency Services by Location (PSAP only)", "find_emergency_services", "What is the 911 service for coordinates -71.0589, 42.3601?",
+             {"location": {"coordinates": [-71.0589, 42.3601]}, "include_ahj": False}),
+            
+            ("Emergency Services by Address (PSAP + AHJ)", "find_emergency_services", "Get Authority Having Jurisdiction for 860 White Plains Road Trumbull CT 06611",
              {"address": {"addressLines": ["860 White Plains Road"], "city": "Trumbull", "admin1": "CT", "postalCode": "06611"}}),
             
-            ("PSAP by Location", "psap_location", "What is the 911 service for coordinates -71.0589, 42.3601?",
+            ("Emergency Services by Location (PSAP + AHJ)", "find_emergency_services", "Get Authority Having Jurisdiction for coordinates -71.0589, 42.3601",
              {"location": {"coordinates": [-71.0589, 42.3601]}}),
             
-            ("PSAP by FCC ID", "psap_ahj_fccid", "Get PSAP information for FCC ID 1404",
+            ("Emergency Services by FCC ID", "find_emergency_services", "Get PSAP information for FCC ID 1404",
              {"fcc_id": "1404"}),
-            
-            ("PSAP AHJ by Address", "psap_ahj_address", "Get Authority Having Jurisdiction for 860 White Plains Road Trumbull CT 06611",
-             {"address": {"addressLines": ["860 White Plains Road"], "city": "Trumbull", "admin1": "CT", "postalCode": "06611"}}),
-            
-            ("PSAP AHJ by Location", "psap_ahj_location", "Get Authority Having Jurisdiction for coordinates -71.0589, 42.3601",
-             {"location": {"coordinates": [-71.0589, 42.3601]}}),
             
             # Property Information
             ("Get Property Data", "get_property_data", "What are the property details for 42 Valley Of The Sun Dr, Fairplay, CO 80440?",
@@ -586,16 +586,7 @@ class PreciselyMCPTestSuite:
              {"tableName": "/risks/historical_weather_windgrid", "aggregateColumns": {"w11": ["min", "max", "avg", "sum"], "w10": ["min", "max", "sum", "avg", "median"]}, "location": {"format": "WKT", "value": "GEOMETRYCOLLECTION (MULTIPOLYGON (((-122.399306 37.712211, -122.398975 37.712132, -122.399007 37.712049, -122.399338 37.712127, -122.399316 37.712185, -122.399306 37.712211))), LINESTRING (-121.756899 37.653383, -121.158302 37.304645, -121.690998 37.120906))"}, "spatialOperation": "intersects", "attributeFilter": "grid_id > 0", "proportionalCalculation": True, "bufferDistance": "10 mi"}),
             
             # OGC Features APIs
-            ("OGC Landing Page", "ogc_landing_page", "Get OGC API landing page",
-             {}),
-            
-            ("OGC API Definition", "ogc_api_definition", "Get OGC API definition",
-             {}),
-            
             ("OGC Functions", "ogc_functions", "Get OGC spatial functions",
-             {}),
-            
-            ("OGC Conformance", "ogc_conformance", "Get OGC conformance declaration",
              {}),
             
             ("OGC Collections", "ogc_collections", "List OGC feature collections",
@@ -613,31 +604,31 @@ class PreciselyMCPTestSuite:
             ("OGC Collection Items", "ogc_collection_items", "Get items from properties/buildings collection with bbox",
              {"collectionId": "properties/buildings", "limit": "100"}),
             
-            ("OGC Feature by ID", "ogc_feature_by_id", "Get feature 1 from properties/buildings collection",
+            ("OGC Feature by ID", "ogc_collection_items", "Get feature 1 from properties/buildings collection",
              {"collectionId": "properties/buildings", "featureId": "1"}),
             
             # WMS APIs
-            ("WMS GetCapabilities", "wms_get_request", "Get WMS capabilities",
+            ("WMS GetCapabilities", "wms_request", "Get WMS capabilities",
              {"REQUEST": "GetCapabilities", "SERVICE": "WMS", "VERSION": "1.3.0"}),
 
             # GetFeatureInfo with INFO_FORMAT=application/json returns a GeoJSON FeatureCollection dict
             # This is handled by the generic Success path in run_functional_test (no image_base64/error/xml key)
             # EPSG:4326 v1.3.0 BBOX axis order is minLat,minLon,maxLat,maxLon (Y-first per CRS definition)
-            ("WMS GetFeatureInfo JSON", "wms_get_request", "Get feature attributes at a pixel as GeoJSON",
+            ("WMS GetFeatureInfo JSON", "wms_request", "Get feature attributes at a pixel as GeoJSON",
              {"REQUEST": "GetFeatureInfo", "SERVICE": "WMS", "VERSION": "1.3.0", "crs": "EPSG:4326", "BBOX": "29.0,-99.5,30.5,-98.0", "width": "400", "height": "300", "layers": "wildfire_risk", "STYLES": "", "QUERY_LAYERS": "wildfire_risk", "Info_Format": "application/json", "I": "200", "J": "150"}),
 
-            ("WMS POST GetMap", "wms_post_get_map", "Get a styled map image via POST with custom SLD_BODY (brown fill buildings)",
+            ("WMS POST GetMap", "wms_request", "Get a styled map image via POST with custom SLD_BODY (brown fill buildings)",
              {"REQUEST": "GetMap", "SERVICE": "WMS", "VERSION": "1.3.0", "crs": "EPSG:4326", "BBOX": "37.78662956646336823,-122.2745967175037549,37.81410536165775227,-122.2403683391127061", "width": "1062", "height": "853", "layers": "buildings", "STYLES": "", "FORMAT": "image/png", "TRANSPARENT": "TRUE", "SLD_BODY": '{"styleDetails": [{"themeList": {"theme": [{"type": "OverrideTheme","style": {"type": "MapBasicCompositeStyle","AreaStyle": {"type": "MapBasicAreaStyle","MapBasicPen": {"width": 1,"pattern": 2,"color": "#964B00","unit": "PIXEL"},"MapBasicBrush": {"pattern": 2,"foregroundColor": "#E0AB8B","backgroundColor": "#C0C0C0"}}}}]}}]}'  }),
             
             # WMTS APIs
             ("WMTS GetCapabilities", "wmts_request", "Get WMTS capabilities",
              {"Service": "WMTS", "Request": "GetCapabilities"}),
             
-            ("WMTS Get Standard Tile", "wmts_get_standard_tile", "Get a standard map tile",
-             {"Version": "1.0.0", "Layer": "parcels", "Style": "default", "TileMatrixSet": "WorldWebMercatorQuad_0_to_19", "TileMatrix": "17", "TileCol": 31118, "TileRow": 50069, "Format": "png"}),
+            ("WMTS GetTile Standard", "wmts_request", "Get a standard map tile via KVP",
+             {"Service": "WMTS", "Request": "GetTile", "Version": "1.0.0", "Layer": "parcels", "Style": "default", "TileMatrixSet": "WorldWebMercatorQuad_0_to_19", "TileMatrix": "17", "TileRow": 50069, "TileCol": 31118, "Format": "image/png"}),
             
-            ("WMTS Get Simple Tile", "wmts_get_simple_tile", "Get a simple map tile",
-             {"Version": "1.0.0", "Layer": "parcels", "TileMatrix": "17", "TileCol": 31118, "TileRow": 50069, "Format": "png"}),
+            ("WMTS GetTile Simple", "wmts_request", "Get a simple profile map tile",
+             {"Service": "WMTS", "Request": "GetTile", "Version": "1.0.0", "Layer": "parcels", "TileMatrix": "17", "TileCol": 31118, "TileRow": 50069, "Format": "png", "profile": "simple"}),
         ]
     
     # ========================================


### PR DESCRIPTION
Update mcp_servers, precisely, readme.md, test_precisely_mcp.py
  - Consolidated & deleted tools; Total tool count down to 51 from 68
  - Updated descriptions to use single triple-quoted string
  - Formatted descriptions into 4 sections
    - Purpose + when to use
    - Do NOT use when / constraints (Routing guidance)
    - Output
    - Examples 
  - Consolidated following tools while preserving all functionality
    - PSAP x5 -> 1
    - Autocomplete x3 -> 1 (deletion of Express pending)
    - Verify email x2 -> 1
    - Parse phone x2 -> 1
    - Parse address x2 -> 1
    - WMS x2 -> 1
    - WMTS x3 -> 1
    - OGC Features "collection_items" + "feature_by_id" -> 1
    - Timezone x2 -> 1
  - Deleted following tools - Didn't need for other tools; Opus concurred
    - OGC Features
     - Landing page
     - API definition
     - Coformance classes
  - Updated tool/various counts
  - Uses official MCP standard best practices
  - Spot tested for key modules
    - demographics
    - map_services
  - Misc. changes

Update map_services.py and timezone.py
  - Fixed bugs post tool consolidation & deletion
    - dis-locate-apis-v2\mcp_servers\tools\map_services.py
    - dis-locate-apis-v2\mcp_servers\tools\timezone.py
  - map_services.py
    - Updated descriptions to use "Output:" instead of "Returns:", again
    - Updated stale layer references - census_state silently removed
  - timezone.py
    - Now has "properties" at inputSchema root; correctly uses oneOf as
      sibling to it
  - Note: Tool output appear twice because response returns both:
    - content=[TextContent(text=json.dumps(result))] (JSON as text str)
    - structuredContent=result (raw dict)
    Per MCP spec, structuredContent is meant for typed access when
    outputSchema is defined on the tool; SDK validates output against
    the schema
  - Uses official MCP standard best practices
  - Spot tested