### PR TITLE
Add GeoX Property, Roof, and Vegetation datalink MCP tools

### DIFF
--- a/dis-locate-apis-v2/mcp_servers/tools/graphql_services.py
+++ b/dis-locate-apis-v2/mcp_servers/tools/graphql_services.py
@@ -1,6 +1,6 @@
 """
 GraphQL Services Tools Module
-Contains 22 tools for property, demographics, risk, and advanced GraphQL queries
+Contains 25 tools for property, demographics, risk, and advanced GraphQL queries
 """
 from mcp.types import Tool
 from mcp_servers.tools.base_tool import handle_tool_call  # noqa: F401
@@ -35,6 +35,27 @@ _GRAPHQL_DATA_SCHEMA = {
         }
     },
     "required": ["query", "variables"]
+}
+
+# Input schema for curated datalink tools that support lookup by address OR by ID.
+_ADDRESS_OR_ID_INPUT_SCHEMA = {
+    "type": "object",
+    "properties": {
+        "address": {
+            "type": "string",
+            "description": "Full street address string for getByAddress mode (e.g., '2755 Milwaukee St, Denver, CO 80238').",
+        },
+        "id": {
+            "type": "string",
+            "description": "Entity identifier for getById mode.",
+        },
+        "queryType": {
+            "type": "string",
+            "description": "ID namespace required when using getById mode.",
+            "enum": ["PRECISELY_ID", "PARCEL_ID", "BUILDING_ID", "PLACE_ID", "DUNS_ID", "GERS_ID"],
+        },
+    },
+    "oneOf": [{"required": ["address"]}, {"required": ["id", "queryType"]}],
 }
 
 
@@ -442,5 +463,93 @@ Example request:
             },
             "required": ["data"]
         }
+    ),
+
+    # Datalink GeoX tools (3 tools) — curated queries, premium credits
+    Tool(
+        name="get_datalink_geox_property",
+        description="""Retrieve Data Link GeoX Property records for a building using aerial/satellite imagery analysis.
+Returns detailed physical building attributes derived from overhead imagery.
+Use this tool when you need building footprint, height, occupancy, pool/trampoline counts,
+or land use derived from imagery rather than assessor records.
+Do NOT use if you need roof condition or vegetation data — use get_datalink_geox_roof or
+get_datalink_geox_vegetation instead.
+
+Two lookup modes — provide exactly one:
+  Mode 1 (by address): provide 'address' only.
+  Mode 2 (by ID):      provide 'id' and 'queryType' only. Do NOT also pass 'address'.
+
+queryType options: PRECISELY_ID, PARCEL_ID, BUILDING_ID, PLACE_ID, DUNS_ID, GERS_ID
+
+Fields returned:
+  buildingID, footprintID, centerLongitude, centerLatitude, coordinateReferenceSystem,
+  footprintAreaSquareFootage, yearBuilt, occupancy, occupancyOfClosestBuildings,
+  landUseDescription, maximumBuildingHeightFeet, minimumGroundHeightFeet,
+  numberOfStories, squareFootage, poolCount, poolEnclosureCount,
+  temporaryPoolCount, trampolineCount, numberOfBuildingsInParcel,
+  imageDate, modelRunDate
+
+Note: Premium dataset — 5+ credits per call. Data access may be blocked depending on credential tier.
+
+Example (by address): {'address': '2755 Milwaukee St, Denver, CO 80238'}
+Example (by ID):      {'id': 'P0000GL41OME', 'queryType': 'PRECISELY_ID'}""",
+        inputSchema=_ADDRESS_OR_ID_INPUT_SCHEMA,
+    ),
+    Tool(
+        name="get_datalink_geox_roof",
+        description="""Retrieve Data Link GeoX Roof records for a building using aerial/satellite imagery analysis.
+Returns detailed roof condition and material attributes derived from overhead imagery.
+Use this tool when you need roof type, material, condition, rust/ponding/discoloration areas,
+solar panel coverage, or air conditioner counts assessed from imagery.
+Do NOT use if you need building footprint or vegetation data — use get_datalink_geox_property or
+get_datalink_geox_vegetation instead.
+
+Two lookup modes — provide exactly one:
+  Mode 1 (by address): provide 'address' only.
+  Mode 2 (by ID):      provide 'id' and 'queryType' only. Do NOT also pass 'address'.
+
+queryType options: PRECISELY_ID, PARCEL_ID, BUILDING_ID, PLACE_ID, DUNS_ID, GERS_ID
+
+Fields returned:
+  buildingID, footprintID, centerLongitude, centerLatitude, coordinateReferenceSystem,
+  roofType, flatAreaSquareFootage, hipAreaSquareFootage,
+  roofMaterial, roofCondition, rustAreaSquareFootage, pondingAreaSquareFootage,
+  tarpEvidence, discolorationAreaSquareFootage, solarPanelAreaSquareFootage,
+  airConditionerCount, imageDate, modelRunDate
+
+Note: Premium dataset — 7+ credits per call. Data access may be blocked depending on credential tier.
+
+Example (by address): {'address': '2755 Milwaukee St, Denver, CO 80238'}
+Example (by ID):      {'id': 'P0000GL41OME', 'queryType': 'PRECISELY_ID'}""",
+        inputSchema=_ADDRESS_OR_ID_INPUT_SCHEMA,
+    ),
+    Tool(
+        name="get_datalink_geox_vegetation",
+        description="""Retrieve Data Link GeoX Vegetation records for a property using aerial/satellite imagery analysis.
+Returns vegetation proximity and zone coverage data derived from overhead imagery.
+Use this tool when you need tree/shrub/vegetation distances, overhang percentages,
+or zone-by-zone coverage breakdowns around a building.
+Do NOT use if you need building structure or roof data — use get_datalink_geox_property or
+get_datalink_geox_roof instead.
+
+Two lookup modes — provide exactly one:
+  Mode 1 (by address): provide 'address' only.
+  Mode 2 (by ID):      provide 'id' and 'queryType' only. Do NOT also pass 'address'.
+
+queryType options: PRECISELY_ID, PARCEL_ID, BUILDING_ID, PLACE_ID, DUNS_ID, GERS_ID
+
+Fields returned:
+  buildingID, footprintID, centerLongitude, centerLatitude, coordinateReferenceSystem,
+  treeOverhangPercent, distanceToTreeFeet, distanceToShrubFeet, distanceToVegetationFeet,
+  treeZone1Percent, treeZone2Percent, treeZone3Percent, treeZone4Percent,
+  shrubZone1Percent, shrubZone2Percent, shrubZone3Percent, shrubZone4Percent,
+  vegetationZone1Percent, vegetationZone2Percent, vegetationZone3Percent, vegetationZone4Percent,
+  imageDate, modelRunDate
+
+Note: Premium dataset — 3+ credits per call. Data access may be blocked depending on credential tier.
+
+Example (by address): {'address': '2755 Milwaukee St, Denver, CO 80238'}
+Example (by ID):      {'id': 'P0000GL41OME', 'queryType': 'PRECISELY_ID'}""",
+        inputSchema=_ADDRESS_OR_ID_INPUT_SCHEMA,
     ),
     ]

--- a/dis-locate-apis-v2/mcp_servers/tools/output_schemas.py
+++ b/dis-locate-apis-v2/mcp_servers/tools/output_schemas.py
@@ -503,6 +503,19 @@ GET_PLACES = _graphql_schema("Points of interest near the address.", {
     "places": _DATA_BLOCK
 })
 
+# Datalink GeoX tools (3 tools)
+GET_DATALINK_GEOX_PROPERTY = _graphql_schema("Data Link GeoX Property — building attributes from aerial imagery.", {
+    "datalinkGeoXProperty": _DATA_BLOCK
+})
+
+GET_DATALINK_GEOX_ROOF = _graphql_schema("Data Link GeoX Roof — roof condition and material from aerial imagery.", {
+    "datalinkGeoXRoof": _DATA_BLOCK
+})
+
+GET_DATALINK_GEOX_VEGETATION = _graphql_schema("Data Link GeoX Vegetation — vegetation proximity and coverage from aerial imagery.", {
+    "datalinkGeoXVegetation": _DATA_BLOCK
+})
+
 # ============================================================
 # Spatial Analysis (7 tools)
 # ============================================================
@@ -814,6 +827,10 @@ TOOL_OUTPUT_SCHEMAS = {
     "get_address_family": GET_ADDRESS_FAMILY,
     "get_serviceability": GET_SERVICEABILITY,
     "get_places_by_address": GET_PLACES,
+    # GraphQL Datalink GeoX (3)
+    "get_datalink_geox_property": GET_DATALINK_GEOX_PROPERTY,
+    "get_datalink_geox_roof": GET_DATALINK_GEOX_ROOF,
+    "get_datalink_geox_vegetation": GET_DATALINK_GEOX_VEGETATION,
     # Spatial Analysis (7)
     "find_nearest_candidates": GEOJSON_FEATURE_COLLECTION,
     "search_at_location": GEOJSON_FEATURE_COLLECTION,

--- a/dis-locate-apis-v2/precisely/__init__.py
+++ b/dis-locate-apis-v2/precisely/__init__.py
@@ -11,7 +11,7 @@ PreciselyAPI is composed from domain-specific mixins, each living in its own mod
     precisely/geolocation.py     — GeolocationMixin (2 methods)
     precisely/property_risk.py   — PropertyRiskMixin (9 methods)
     precisely/demographics.py    — DemographicsMixin (8 methods)
-    precisely/graphql_advanced.py — GraphQLAdvancedMixin (5 methods)
+    precisely/graphql_advanced.py — GraphQLAdvancedMixin (8 methods)
     precisely/spatial.py         — SpatialMixin (7 methods)
     precisely/map_services.py    — MapServicesMixin (15 methods)
 """
@@ -42,7 +42,7 @@ class PreciselyAPI(
     MapServicesMixin,
     BaseClient,
 ):
-    """Precisely API client — all 72 methods across 10 domain modules."""
+    """Precisely API client — all 75 methods across 10 domain modules."""
 
 
 __all__ = ["PreciselyAPI"]

--- a/dis-locate-apis-v2/precisely/graphql_advanced.py
+++ b/dis-locate-apis-v2/precisely/graphql_advanced.py
@@ -1,10 +1,39 @@
-"""Advanced GraphQL API methods (5 tools — LLM constructs queries directly)."""
+"""Advanced GraphQL API methods (8 tools — 5 LLM-constructed + 3 curated datalink queries)."""
 
 import json
 import logging
 from typing import Any, Dict
 
 logger = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Curated GeoX query templates (address mode)
+# ---------------------------------------------------------------------------
+
+_GEOX_PROPERTY_FIELDS = """
+                buildingID footprintID centerLongitude centerLatitude coordinateReferenceSystem
+                footprintAreaSquareFootage yearBuilt occupancy occupancyOfClosestBuildings
+                landUseDescription maximumBuildingHeightFeet minimumGroundHeightFeet
+                numberOfStories squareFootage poolCount poolEnclosureCount
+                temporaryPoolCount trampolineCount numberOfBuildingsInParcel
+                imageDate modelRunDate""".strip()
+
+_GEOX_ROOF_FIELDS = """
+                buildingID footprintID centerLongitude centerLatitude coordinateReferenceSystem
+                roofType flatAreaSquareFootage hipAreaSquareFootage
+                roofMaterial roofCondition rustAreaSquareFootage pondingAreaSquareFootage
+                tarpEvidence discolorationAreaSquareFootage solarPanelAreaSquareFootage
+                airConditionerCount imageDate modelRunDate""".strip()
+
+_GEOX_VEGETATION_FIELDS = """
+                buildingID footprintID centerLongitude centerLatitude coordinateReferenceSystem
+                treeOverhangPercent distanceToTreeFeet distanceToShrubFeet distanceToVegetationFeet
+                treeZone1Percent treeZone2Percent treeZone3Percent treeZone4Percent
+                shrubZone1Percent shrubZone2Percent shrubZone3Percent shrubZone4Percent
+                vegetationZone1Percent vegetationZone2Percent vegetationZone3Percent vegetationZone4Percent
+                imageDate modelRunDate""".strip()
+
+_METADATA_FIELDS = "pageNumber pageCount totalPages count vintage"
 
 
 class GraphQLAdvancedMixin:
@@ -77,3 +106,124 @@ class GraphQLAdvancedMixin:
         except Exception as e:
             logger.error(f"Places by address error: {e}")
             return self._build_error("Places by address", e)
+
+    # ------------------------------------------------------------------
+    # Curated datalink helpers — address OR id+queryType
+    # ------------------------------------------------------------------
+
+    def _call_datalink(
+        self,
+        tool_name: str,
+        gql_field: str,
+        data_fields: str,
+        address: str | None,
+        entity_id: str | None,
+        query_type: str | None,
+    ) -> Dict[str, Any]:
+        """Shared implementation for curated datalink GeoX tools."""
+        has_address = bool(address)
+        has_id_mode = bool(entity_id and query_type)
+
+        if has_address and has_id_mode:
+            raise ValueError(
+                f"[{tool_name}] Provide only one lookup mode: either 'address' or both 'id' and 'queryType', not both."
+            )
+        if not has_address and not has_id_mode:
+            raise ValueError(
+                f"[{tool_name}] Must provide either 'address' or both 'id' and 'queryType'."
+            )
+
+        if has_address:
+            json_data = {
+                "query": (
+                    f"query Get{gql_field}ByAddress($address: String!) {{"
+                    f" getByAddress(address: $address) {{"
+                    f" {gql_field} {{"
+                    f" metadata {{ {_METADATA_FIELDS} }}"
+                    f" data {{ {data_fields} }}"
+                    f" }} }} }}"
+                ),
+                "variables": {"address": address},
+            }
+        else:
+            json_data = {
+                "query": (
+                    f"query Get{gql_field}ById($id: String!, $queryType: QueryType!) {{"
+                    f" getById(id: $id, queryType: $queryType) {{"
+                    f" {gql_field} {{"
+                    f" metadata {{ {_METADATA_FIELDS} }}"
+                    f" data {{ {data_fields} }}"
+                    f" }} }} }}"
+                ),
+                "variables": {"id": entity_id, "queryType": query_type},
+            }
+
+        url = f"{self.base_url}/data-graph/graphql"
+        logger.debug(f"[{tool_name}] Request payload: {json.dumps(json_data, indent=2)}")
+        response = self.session.post(url, json=json_data)
+        logger.debug(f"[{tool_name}] Raw response: {response.text}")
+        response.raise_for_status()
+        return self._validate_graphql_response(response.json(), tool_name)
+
+    def get_datalink_geox_property(
+        self,
+        address: str | None = None,
+        id: str | None = None,
+        queryType: str | None = None,
+        **kwargs,
+    ) -> Dict[str, Any]:
+        """Get Data Link GeoX Property by address or by ID. Premium: 5+ credits/call."""
+        try:
+            return self._call_datalink(
+                "get_datalink_geox_property",
+                "datalinkGeoXProperty",
+                _GEOX_PROPERTY_FIELDS,
+                address,
+                id,
+                queryType,
+            )
+        except Exception as e:
+            logger.error(f"Data Link GeoX Property error: {e}")
+            return self._build_error("Data Link GeoX Property", e)
+
+    def get_datalink_geox_roof(
+        self,
+        address: str | None = None,
+        id: str | None = None,
+        queryType: str | None = None,
+        **kwargs,
+    ) -> Dict[str, Any]:
+        """Get Data Link GeoX Roof by address or by ID. Premium: 7+ credits/call."""
+        try:
+            return self._call_datalink(
+                "get_datalink_geox_roof",
+                "datalinkGeoXRoof",
+                _GEOX_ROOF_FIELDS,
+                address,
+                id,
+                queryType,
+            )
+        except Exception as e:
+            logger.error(f"Data Link GeoX Roof error: {e}")
+            return self._build_error("Data Link GeoX Roof", e)
+
+    def get_datalink_geox_vegetation(
+        self,
+        address: str | None = None,
+        id: str | None = None,
+        queryType: str | None = None,
+        **kwargs,
+    ) -> Dict[str, Any]:
+        """Get Data Link GeoX Vegetation by address or by ID. Premium: 3+ credits/call."""
+        try:
+            return self._call_datalink(
+                "get_datalink_geox_vegetation",
+                "datalinkGeoXVegetation",
+                _GEOX_VEGETATION_FIELDS,
+                address,
+                id,
+                queryType,
+            )
+        except Exception as e:
+            logger.error(f"Data Link GeoX Vegetation error: {e}")
+            return self._build_error("Data Link GeoX Vegetation", e)


### PR DESCRIPTION
## Summary
- Adds three new curated-query MCP tools backed by Data Link GeoX aerial imagery data:
  - `get_datalink_geox_property` — building footprint, height, occupancy, pool/trampoline counts (5+ credits/call)
  - `get_datalink_geox_roof` — roof type, material, condition, rust/ponding/solar panel areas (7+ credits/call)
  - `get_datalink_geox_vegetation` — tree/shrub distances and zone coverage percentages (3+ credits/call)
- Each tool supports two lookup modes: **address** (`getByAddress`) or **id + queryType** (`getById`), validated at the Python layer before the GraphQL request is sent
- Shared `_call_datalink` helper eliminates boilerplate across the three methods
- GraphQL field sets defined as module-level string constants — avoids the indentation/readability issue seen in PR #51
- Mutual-exclusion validation has distinct error messages for "both provided" vs "neither provided"
- Output schemas registered in `TOOL_OUTPUT_SCHEMAS`
- Tool count: 22 → 25 | `GraphQLAdvancedMixin`: 5 → 8 methods

## Test plan
- [ ] `get_datalink_geox_property` with a valid US address returns `datalinkGeoXProperty.data` records
- [ ] `get_datalink_geox_roof` with a valid US address returns `datalinkGeoXRoof.data` records
- [ ] `get_datalink_geox_vegetation` with a valid US address returns `datalinkGeoXVegetation.data` records
- [ ] All three tools work in `id + queryType` (getById) mode with `PRECISELY_ID`
- [ ] Passing both `address` and `id` returns a clear validation error
- [ ] Passing neither `address` nor `id`/`queryType` returns a clear validation error
- [ ] Permission-blocked credentials return a structured error response (not an unhandled exception)

🤖 Generated with [Claude Code](https://claude.com/claude-code)