### PR TITLE
Add get_historical_sales MCP tool for full deed and loan history

### DIFF
--- a/dis-locate-apis-v2/mcp_servers/tools/graphql_services.py
+++ b/dis-locate-apis-v2/mcp_servers/tools/graphql_services.py
@@ -1,6 +1,6 @@
 """
 GraphQL Services Tools Module
-Contains 22 tools for property, demographics, risk, and advanced GraphQL queries
+Contains 23 tools for property, demographics, risk, and advanced GraphQL queries
 """
 from mcp.types import Tool
 from mcp_servers.tools.base_tool import handle_tool_call  # noqa: F401
@@ -35,6 +35,27 @@ _GRAPHQL_DATA_SCHEMA = {
         }
     },
     "required": ["query", "variables"]
+}
+
+# Input schema for curated datalink tools that support lookup by address OR by ID.
+_ADDRESS_OR_ID_INPUT_SCHEMA = {
+    "type": "object",
+    "properties": {
+        "address": {
+            "type": "string",
+            "description": "Full street address string for getByAddress mode (e.g., '2755 Milwaukee St, Denver, CO 80238').",
+        },
+        "id": {
+            "type": "string",
+            "description": "Entity identifier for getById mode.",
+        },
+        "queryType": {
+            "type": "string",
+            "description": "ID namespace required when using getById mode.",
+            "enum": ["PRECISELY_ID", "PARCEL_ID", "BUILDING_ID", "PLACE_ID", "DUNS_ID", "GERS_ID"],
+        },
+    },
+    "oneOf": [{"required": ["address"]}, {"required": ["id", "queryType"]}],
 }
 
 
@@ -442,5 +463,65 @@ Example request:
             },
             "required": ["data"]
         }
+    ),
+
+    # Historical Sales (1 tool) — curated full deed + loan query
+    Tool(
+        name="get_historical_sales",
+        description="""Retrieve the full deed and loan/mortgage transaction history for a property.
+Returns every recorded sale event including buyer/seller identities, legal description,
+deed type, sale price, transfer taxes, and the complete loan/mortgage block for each transaction.
+
+Use this tool when you need:
+- Past ownership chain (who bought/sold and when)
+- Sale prices and transfer tax history
+- Loan/mortgage details for each transaction (lender, amount, type, rate, term)
+- Legal description and recording metadata per transaction
+
+Do NOT use for current property attributes — use get_property_data or get_property_attributes_by_address instead.
+Do NOT use for assessed/replacement value — use get_replacement_cost_by_address instead.
+
+Two lookup modes — provide exactly one:
+  Mode 1 (by address): provide 'address' only.
+  Mode 2 (by ID):      provide 'id' and 'queryType' only. Do NOT also pass 'address'.
+
+queryType options: PRECISELY_ID, PARCEL_ID, BUILDING_ID, PLACE_ID, DUNS_ID, GERS_ID
+
+Fields returned per record:
+  Core IDs:      historicalPropertyAttributeID, propertyAttributeID, preciselyID, parentPreciselyID, plinkID
+  Seller:        sellerFirstName, sellerLastName, sellerIDCode, seller2FirstName, seller2LastName, seller2IDCode,
+                 sellerMailAddress, sellerMailCity, sellerMailState, sellerMailPostalCode
+  Buyer:         buyerFirstName, buyerLastCorporationName, buyerIDCode, buyer2FirstName, buyer2LastCorporationName,
+                 buyer2IDCode, buyerVestCode, buyerMailCareOf, buyerMailAddress, buyerMailCity,
+                 buyerMailState, buyerMailPostalCode
+  Property:      addressLine, city, state, postalCode, postalCodeExtension, propertyAPN, apnSequence,
+                 fips, propertyUseCode
+  Deed/Recording: deedDocumentTypeCode, interFamily, recordingDate, recordersBookNumber,
+                 recordersPageNumber, recordersDocumentNumber, partialInterestTransferred
+  Legal:         legalLotCode, legalLotNumbers, legalBlock, legalSection, legalDistrict, legalLandLot,
+                 legalUnit, legalCityTownshipMunicipality, legalSubdivisionName, legalPhaseNumber,
+                 legalTractNumber, legalShortDescription, legalSectionTownshipRangeMeridian, legalDescriptionCode
+  Transaction:   recordersMapReference, deedTransactionType, recorderDocumentNumber, contractDate,
+                 salesPriceUSD, salesPriceCode, cityTransferTax, stateTransferTax, totalTransferTax
+  Loan:          lenderName, lenderType, loanAmountUSD, loanType, financingType, initialRate, dueDate,
+                 loanAmountSecondUSD, adjustableRateRider, adjustableRateIndex, changeIndex,
+                 rateChangeFrequency, interestRateAdjustableMaximum, interestRateAdjustableMinimum,
+                 interestRateMaximum, interestOnlyPeriod, interestRate, fixedChangeDateYear,
+                 fixedChangeFullDateMonthDay, prepaymentRider, prepaymentTermPenalty, titleCompanyName,
+                 realEstateOwnedFlag, distressedSaleFlag, loanOriginatorOrganizationIDNumber,
+                 loanOrganizationName, mortgageBrokerNMLSID, mortgageBroker, loanOfficerNMLSID,
+                 loanOfficerName, loanTransactionType
+
+Enum fields (each returns { value, description }): sellerIDCode, seller2IDCode, buyerIDCode, buyer2IDCode,
+  buyerVestCode, apnSequence, propertyUseCode, deedDocumentTypeCode, partialInterestTransferred,
+  legalLotCode, legalDescriptionCode, deedTransactionType, salesPriceCode, lenderType, loanType,
+  financingType, adjustableRateRider, adjustableRateIndex, rateChangeFrequency, interestRate,
+  prepaymentRider, realEstateOwnedFlag, loanTransactionType
+
+Note: Large response payload (~2400 chars query). Data access may be limited by credential tier.
+
+Example (by address): {'address': '2755 Milwaukee St, Denver, CO 80238'}
+Example (by ID):      {'id': 'P0000GL41OME', 'queryType': 'PRECISELY_ID'}""",
+        inputSchema=_ADDRESS_OR_ID_INPUT_SCHEMA,
     ),
     ]

--- a/dis-locate-apis-v2/mcp_servers/tools/output_schemas.py
+++ b/dis-locate-apis-v2/mcp_servers/tools/output_schemas.py
@@ -503,6 +503,10 @@ GET_PLACES = _graphql_schema("Points of interest near the address.", {
     "places": _DATA_BLOCK
 })
 
+GET_HISTORICAL_SALES = _graphql_schema("Full deed and loan/mortgage transaction history.", {
+    "historicalSales": _DATA_BLOCK
+})
+
 # ============================================================
 # Spatial Analysis (7 tools)
 # ============================================================
@@ -808,12 +812,13 @@ TOOL_OUTPUT_SCHEMAS = {
     "get_schools_by_address": GET_SCHOOLS,
     "get_buildings_by_address": GET_BUILDINGS,
     "get_parcels_by_address": GET_PARCELS,
-    # GraphQL Advanced (5)
+    # GraphQL Advanced (6)
     "get_addresses_detailed": GET_ADDRESSES_DETAILED,
     "get_parcel_by_owner_detailed": GET_PARCEL_BY_OWNER,
     "get_address_family": GET_ADDRESS_FAMILY,
     "get_serviceability": GET_SERVICEABILITY,
     "get_places_by_address": GET_PLACES,
+    "get_historical_sales": GET_HISTORICAL_SALES,
     # Spatial Analysis (7)
     "find_nearest_candidates": GEOJSON_FEATURE_COLLECTION,
     "search_at_location": GEOJSON_FEATURE_COLLECTION,

--- a/dis-locate-apis-v2/precisely/__init__.py
+++ b/dis-locate-apis-v2/precisely/__init__.py
@@ -11,7 +11,7 @@ PreciselyAPI is composed from domain-specific mixins, each living in its own mod
     precisely/geolocation.py     — GeolocationMixin (2 methods)
     precisely/property_risk.py   — PropertyRiskMixin (9 methods)
     precisely/demographics.py    — DemographicsMixin (8 methods)
-    precisely/graphql_advanced.py — GraphQLAdvancedMixin (5 methods)
+    precisely/graphql_advanced.py — GraphQLAdvancedMixin (6 methods)
     precisely/spatial.py         — SpatialMixin (7 methods)
     precisely/map_services.py    — MapServicesMixin (15 methods)
 """
@@ -42,7 +42,7 @@ class PreciselyAPI(
     MapServicesMixin,
     BaseClient,
 ):
-    """Precisely API client — all 72 methods across 10 domain modules."""
+    """Precisely API client — all 73 methods across 10 domain modules."""
 
 
 __all__ = ["PreciselyAPI"]

--- a/dis-locate-apis-v2/precisely/graphql_advanced.py
+++ b/dis-locate-apis-v2/precisely/graphql_advanced.py
@@ -1,10 +1,63 @@
-"""Advanced GraphQL API methods (5 tools — LLM constructs queries directly)."""
+"""Advanced GraphQL API methods (6 tools — 5 LLM-constructed + 1 curated datalink query)."""
 
 import json
 import logging
 from typing import Any, Dict
 
 logger = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Curated historical sales query — full deed + loan field set
+# ---------------------------------------------------------------------------
+
+_METADATA_FIELDS = "pageNumber pageCount totalPages count vintage"
+
+_HISTORICAL_SALES_FIELDS = (
+    # Core IDs
+    "historicalPropertyAttributeID propertyAttributeID "
+    "preciselyID parentPreciselyID plinkID "
+    # Seller parties
+    "sellerFirstName sellerLastName sellerIDCode { value description } "
+    "seller2FirstName seller2LastName seller2IDCode { value description } "
+    "sellerMailAddress sellerMailCity sellerMailState sellerMailPostalCode "
+    # Buyer parties
+    "buyerFirstName buyerLastCorporationName buyerIDCode { value description } "
+    "buyer2FirstName buyer2LastCorporationName buyer2IDCode { value description } "
+    "buyerVestCode { value description } "
+    "buyerMailCareOf buyerMailAddress buyerMailCity buyerMailState buyerMailPostalCode "
+    # Property identifiers
+    "addressLine city state postalCode postalCodeExtension "
+    "propertyAPN apnSequence { value description } fips "
+    "propertyUseCode { value description } "
+    # Deed / recording
+    "deedDocumentTypeCode { value description } "
+    "interFamily recordingDate recordersBookNumber recordersPageNumber recordersDocumentNumber "
+    "partialInterestTransferred { value description } "
+    # Legal description
+    "legalLotCode { value description } "
+    "legalLotNumbers legalBlock legalSection legalDistrict legalLandLot legalUnit "
+    "legalCityTownshipMunicipality legalSubdivisionName legalPhaseNumber legalTractNumber "
+    "legalShortDescription legalSectionTownshipRangeMeridian "
+    "legalDescriptionCode { value description } "
+    # Transaction financials
+    "recordersMapReference deedTransactionType { value description } "
+    "recorderDocumentNumber contractDate salesPriceUSD salesPriceCode { value description } "
+    "cityTransferTax stateTransferTax totalTransferTax "
+    # Loan / mortgage
+    "lenderName lenderType { value description } "
+    "loanAmountUSD loanType { value description } financingType { value description } "
+    "initialRate dueDate loanAmountSecondUSD "
+    "adjustableRateRider { value description } adjustableRateIndex { value description } "
+    "changeIndex rateChangeFrequency { value description } "
+    "interestRateAdjustableMaximum interestRateAdjustableMinimum interestRateMaximum "
+    "interestOnlyPeriod interestRate { value description } "
+    "fixedChangeDateYear fixedChangeFullDateMonthDay "
+    "prepaymentRider { value description } prepaymentTermPenalty "
+    "titleCompanyName realEstateOwnedFlag { value description } distressedSaleFlag "
+    "loanOriginatorOrganizationIDNumber loanOrganizationName "
+    "mortgageBrokerNMLSID mortgageBroker loanOfficerNMLSID loanOfficerName "
+    "loanTransactionType { value description }"
+)
 
 
 class GraphQLAdvancedMixin:
@@ -77,3 +130,82 @@ class GraphQLAdvancedMixin:
         except Exception as e:
             logger.error(f"Places by address error: {e}")
             return self._build_error("Places by address", e)
+
+    # ------------------------------------------------------------------
+    # Curated datalink helper — address OR id+queryType
+    # ------------------------------------------------------------------
+
+    def _call_datalink(
+        self,
+        tool_name: str,
+        gql_field: str,
+        data_fields: str,
+        address: str | None,
+        entity_id: str | None,
+        query_type: str | None,
+    ) -> Dict[str, Any]:
+        """Shared implementation for curated datalink tools."""
+        has_address = bool(address)
+        has_id_mode = bool(entity_id and query_type)
+
+        if has_address and has_id_mode:
+            raise ValueError(
+                f"[{tool_name}] Provide only one lookup mode: either 'address' or both 'id' and 'queryType', not both."
+            )
+        if not has_address and not has_id_mode:
+            raise ValueError(
+                f"[{tool_name}] Must provide either 'address' or both 'id' and 'queryType'."
+            )
+
+        if has_address:
+            json_data = {
+                "query": (
+                    f"query Get{gql_field}ByAddress($address: String!) {{"
+                    f" getByAddress(address: $address) {{"
+                    f" {gql_field} {{"
+                    f" metadata {{ {_METADATA_FIELDS} }}"
+                    f" data {{ {data_fields} }}"
+                    f" }} }} }}"
+                ),
+                "variables": {"address": address},
+            }
+        else:
+            json_data = {
+                "query": (
+                    f"query Get{gql_field}ById($id: String!, $queryType: QueryType!) {{"
+                    f" getById(id: $id, queryType: $queryType) {{"
+                    f" {gql_field} {{"
+                    f" metadata {{ {_METADATA_FIELDS} }}"
+                    f" data {{ {data_fields} }}"
+                    f" }} }} }}"
+                ),
+                "variables": {"id": entity_id, "queryType": query_type},
+            }
+
+        url = f"{self.base_url}/data-graph/graphql"
+        logger.debug(f"[{tool_name}] Request payload: {json.dumps(json_data, indent=2)}")
+        response = self.session.post(url, json=json_data)
+        logger.debug(f"[{tool_name}] Raw response: {response.text}")
+        response.raise_for_status()
+        return self._validate_graphql_response(response.json(), tool_name)
+
+    def get_historical_sales(
+        self,
+        address: str | None = None,
+        id: str | None = None,
+        queryType: str | None = None,
+        **kwargs,
+    ) -> Dict[str, Any]:
+        """Get full deed and loan history for a property by address or ID."""
+        try:
+            return self._call_datalink(
+                "get_historical_sales",
+                "historicalSales",
+                _HISTORICAL_SALES_FIELDS,
+                address,
+                id,
+                queryType,
+            )
+        except Exception as e:
+            logger.error(f"Historical sales error: {e}")
+            return self._build_error("Historical sales", e)


### PR DESCRIPTION
## Summary
- Adds a new curated-query MCP tool `get_historical_sales` that fetches the complete deed and loan/mortgage transaction history for a property
- Covers the full field set from spec item 13 (~2400 char query), including:
  - **Buyer/seller parties** with names, vesting codes, mailing addresses, and second-party fields
  - **Deed & recording** — document type, recording date, recorders book/page/document numbers, inter-family flag
  - **Legal description** — lot, block, section, district, subdivision, phase, tract, section-township-range
  - **Transaction financials** — contract date, sale price, price code, city/state/total transfer taxes
  - **Full loan/mortgage block** — lender name/type, loan amount, loan type, financing type, adjustable-rate terms, prepayment rider, NMLS IDs, loan officer, distressed sale flag
- Supports two lookup modes: **address** (`getByAddress`) or **id + queryType** (`getById`), validated at the Python layer before the GraphQL request
- Uses the same `_call_datalink` shared helper pattern introduced for datalink tools (clean indentation, distinct validation error messages)
- All enum fields (`sellerIDCode`, `buyerIDCode`, `deedDocumentTypeCode`, `loanType`, etc.) return `{ value description }` sub-selections
- Output schema registered in `TOOL_OUTPUT_SCHEMAS`
- Tool count: 22 → 23 | `GraphQLAdvancedMixin`: 5 → 6 methods

## Test plan
- [ ] `get_historical_sales` with a valid US address returns `historicalSales.data` records with deed and loan fields populated
- [ ] ID mode (`id` + `queryType: PRECISELY_ID`) returns the same record set as address mode for a known property
- [ ] Passing both `address` and `id` returns a clear validation error
- [ ] Passing neither returns a clear validation error
- [ ] Enum fields (e.g. `sellerIDCode`, `loanType`) each return `{ value, description }` objects
- [ ] Permission-blocked credential tier returns a structured error (not an unhandled exception)

🤖 Generated with [Claude Code](https://claude.com/claude-code)